### PR TITLE
특정 게시글 검색 및 조회, 게시판 페이지 기능 API 추가

### DIFF
--- a/src/main/java/com/walking/project_walking/controller/BoardsController.java
+++ b/src/main/java/com/walking/project_walking/controller/BoardsController.java
@@ -1,0 +1,22 @@
+package com.walking.project_walking.controller;
+
+import com.walking.project_walking.service.BoardsService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/boards")
+public class BoardsController {
+    private final BoardsService boardsService;
+
+    public BoardsController(BoardsService boardsService) {
+        this.boardsService = boardsService;
+    }
+
+    @GetMapping("/{boardId}/pagescount")
+    public int getPostsCount(@PathVariable Long boardId) {
+        return boardsService.getPageCount(boardId);
+    }
+}

--- a/src/main/java/com/walking/project_walking/controller/PostsController.java
+++ b/src/main/java/com/walking/project_walking/controller/PostsController.java
@@ -1,0 +1,39 @@
+package com.walking.project_walking.controller;
+
+import com.walking.project_walking.domain.dto.PostResponseDto;
+import com.walking.project_walking.service.PostsService;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/posts")
+public class PostsController {
+    private final PostsService postsService;
+
+    public PostsController(PostsService postsService) {
+        this.postsService = postsService;
+    }
+
+    @GetMapping
+    public List<PostResponseDto> getPostsByBoard(
+            @RequestParam("board") Long boardId,
+            @RequestParam(defaultValue = "1") int page) {
+
+        PageRequest pageRequest = PageRequest.of(page - 1, 6);
+        return postsService.getPostsByBoardId(boardId, pageRequest);
+    }
+
+    @GetMapping("/{boardId}/posts/search")
+    public List<PostResponseDto> searchPosts(
+            @PathVariable Long boardId,
+            @RequestParam(required = false) String title,
+            @RequestParam(required = false) String content,
+            @RequestParam(required = false) Long userId,
+            @RequestParam(defaultValue = "1") int page) {
+
+        PageRequest pageRequest = PageRequest.of(page - 1, 6);
+        return postsService.searchPosts(boardId, title, content, userId, pageRequest);
+    }
+
+}

--- a/src/main/java/com/walking/project_walking/domain/dto/PostResponseDto.java
+++ b/src/main/java/com/walking/project_walking/domain/dto/PostResponseDto.java
@@ -1,0 +1,33 @@
+package com.walking.project_walking.domain.dto;
+
+import com.walking.project_walking.domain.Posts;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+@Getter
+public class PostResponseDto {
+    private Long boardId;
+    private LocalDateTime createdAt;
+    private String postImage;
+    private String title;
+    private Integer commentsCount;
+    private String content;
+    private Integer viewCount;
+    private Integer likes;
+    private Long userId;
+
+    public static PostResponseDto fromEntity(Posts post, Integer commentsNumber) {
+        PostResponseDto dto = new PostResponseDto();
+        dto.boardId = post.getBoardId();
+        dto.createdAt = post.getCreatedAt();
+        dto.postImage = post.getPostImage();
+        dto.title = post.getTitle();
+        dto.commentsCount = commentsNumber;
+        dto.content = post.getContent();
+        dto.viewCount = post.getViewCount();
+        dto.likes = post.getLikes();
+        dto.userId = post.getUserId();
+        return dto;
+    }
+
+}

--- a/src/main/java/com/walking/project_walking/repository/CommentsRepository.java
+++ b/src/main/java/com/walking/project_walking/repository/CommentsRepository.java
@@ -1,0 +1,12 @@
+package com.walking.project_walking.repository;
+
+import com.walking.project_walking.domain.Comments;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentsRepository extends JpaRepository<Comments, Long> {
+    @Query("SELECT COUNT(c) FROM Comments c WHERE c.postId = ?1 AND (c.isDeleted IS NULL OR c.isDeleted = false)")
+    Integer countCommentsByPostId(Long postId);
+}

--- a/src/main/java/com/walking/project_walking/repository/PostsRepository.java
+++ b/src/main/java/com/walking/project_walking/repository/PostsRepository.java
@@ -1,0 +1,19 @@
+package com.walking.project_walking.repository;
+
+import com.walking.project_walking.domain.Posts;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostsRepository extends JpaRepository<Posts, Long> {
+    Page<Posts> findByBoardId(Long boardId, Pageable pageable);
+
+    @Query("SELECT p FROM Posts p WHERE p.boardId = ?1 AND " +
+            "(LOWER(p.title) LIKE LOWER(CONCAT('%', ?2, '%')) OR " +
+            "LOWER(p.content) LIKE LOWER(CONCAT('%', ?3, '%')) OR " +
+            "p.userId = ?4)")
+    Page<Posts> searchPosts(Long boardId, String title, String content, Long userId, Pageable pageable);
+}

--- a/src/main/java/com/walking/project_walking/service/BoardsService.java
+++ b/src/main/java/com/walking/project_walking/service/BoardsService.java
@@ -1,0 +1,21 @@
+package com.walking.project_walking.service;
+
+import com.walking.project_walking.domain.Posts;
+import com.walking.project_walking.repository.PostsRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BoardsService {
+    private final PostsRepository postsRepository;
+
+    public BoardsService(PostsRepository boardsRepository) {
+        this.postsRepository = boardsRepository;
+    }
+
+    public int getPageCount(Long boardId) {
+        Page<Posts> postsPage = postsRepository.findByBoardId(boardId, PageRequest.of(0, 6));
+        return postsPage.getTotalPages();
+    }
+}

--- a/src/main/java/com/walking/project_walking/service/PostsService.java
+++ b/src/main/java/com/walking/project_walking/service/PostsService.java
@@ -1,0 +1,40 @@
+package com.walking.project_walking.service;
+
+import com.walking.project_walking.domain.Posts;
+import com.walking.project_walking.domain.dto.PostResponseDto;
+import com.walking.project_walking.repository.CommentsRepository;
+import com.walking.project_walking.repository.PostsRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class PostsService {
+    private final PostsRepository postsRepository;
+    private final CommentsRepository commentsRepository;
+
+    public PostsService(PostsRepository postsRepository, CommentsRepository commentsRepository) {
+        this.postsRepository = postsRepository;
+        this.commentsRepository = commentsRepository;
+    }
+
+    public List<PostResponseDto> getPostsByBoardId(Long boardId, PageRequest pageRequest) {
+        return postsRepository.findByBoardId(boardId, pageRequest)
+                .map(post -> {
+                    Integer commentsNumber = commentsRepository.countCommentsByPostId(post.getPostId());
+                    return PostResponseDto.fromEntity(post, commentsNumber);
+                }).toList();
+    }
+
+    public List<PostResponseDto> searchPosts(Long boardId, String title, String content, Long userId, PageRequest pageRequest) {
+        Page<Posts> postsPage = postsRepository.searchPosts(boardId, title, content, userId, pageRequest);
+        return postsPage.getContent().stream()
+                .map(post -> {
+                    Integer commentsNumber = commentsRepository.countCommentsByPostId(post.getPostId());
+                    return PostResponseDto.fromEntity(post, commentsNumber);
+                })
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
### BoardsController, BoardsService
- 특정 게시판에 대한 총 페이지 수를 파악

### PostsController, PostsService
- 특정 게시판에 해당하는 게시글 목록 조회 (페이지 별 6 항목씩)
- 제목, 내용, 글쓴이를 통한 게시글 검색