### PR TITLE
팔로우 기능 개선 및 포인트, 최근 게시글 조회 기능 추가

### DIFF
--- a/src/main/java/com/walking/project_walking/controller/FollowController.java
+++ b/src/main/java/com/walking/project_walking/controller/FollowController.java
@@ -1,5 +1,6 @@
 package com.walking.project_walking.controller;
 
+import com.walking.project_walking.domain.Follow;
 import com.walking.project_walking.domain.Users;
 import com.walking.project_walking.domain.followdto.FollowProfileDto;
 import com.walking.project_walking.service.FollowService;
@@ -25,22 +26,32 @@ public class FollowController {
         return ResponseEntity.ok("해당 유저를 팔로우 합니다.");
     }
 
-    // 팔로잉을 조회
+    // 팔로잉을 조회 - 에러메시지 프로트에서 출력되도록 하기!
     @GetMapping("/users/{userId}/following")
     public ResponseEntity<List<FollowProfileDto>> getFollowing(
             @PathVariable Long userId
     ) {
-        List<FollowProfileDto> followings = followService.getFollowing(userId);
-        return ResponseEntity.ok(followings);
+        List<Follow> followings = followService.getFollowing(userId);
+
+        List<FollowProfileDto> followingDto = followings.stream()
+                .map(FollowProfileDto::new) // Follow 객체를 이용해 FollowProfileDto 생성
+                .toList();
+
+        return ResponseEntity.ok(followingDto);
     }
 
-    // 팔로워를 조회
+    // 팔로워를 조회 - "
     @GetMapping("/users/{userId}/follower")
     public ResponseEntity<List<FollowProfileDto>> getFollower(
             @PathVariable Long userId
     ) {
-        List<FollowProfileDto> followers = followService.getFollower(userId);
-        return ResponseEntity.ok(followers);
+        List<Follow> followers = followService.getFollower(userId);
+
+        List<FollowProfileDto> followerDto = followers.stream()
+                .map(FollowProfileDto::new)
+                .toList();
+
+        return ResponseEntity.ok(followerDto);
     }
 
 }

--- a/src/main/java/com/walking/project_walking/controller/UserController.java
+++ b/src/main/java/com/walking/project_walking/controller/UserController.java
@@ -92,7 +92,6 @@ public class UserController {
     }
 
     // (User) 유저 조회
-    // todo 팔로잉, 팔로워 수 카운트 처리하기
     @GetMapping("/users/{userId}/info")
     public ResponseEntity<UserDetailDto> getUserDetail(
             @PathVariable Long userId

--- a/src/main/java/com/walking/project_walking/controller/UserController.java
+++ b/src/main/java/com/walking/project_walking/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.walking.project_walking.controller;
 
+import com.walking.project_walking.domain.MyGoods;
 import com.walking.project_walking.domain.PointLog;
 import com.walking.project_walking.domain.Users;
 import com.walking.project_walking.domain.userdto.*;
@@ -121,6 +122,15 @@ public class UserController {
                 .map(UserPointLogDto::new)
                 .toList();
         return ResponseEntity.ok(userPointLogDtos);
+    }
+
+    // 유저 아이템 조회
+    @GetMapping("/users/{userId}/items")
+    public ResponseEntity<List<MyGoods>> getMyItems(
+            @PathVariable Long userId
+    ) {
+        List<MyGoods> myGoods = userservice.getGoods(userId);
+        return ResponseEntity.ok(myGoods);
     }
 
 

--- a/src/main/java/com/walking/project_walking/domain/followdto/FollowProfileDto.java
+++ b/src/main/java/com/walking/project_walking/domain/followdto/FollowProfileDto.java
@@ -1,11 +1,19 @@
 package com.walking.project_walking.domain.followdto;
 
+import com.walking.project_walking.domain.Follow;
+import com.walking.project_walking.domain.Users;
 import lombok.*;
 
 @RequiredArgsConstructor
 @Getter
-@Setter
 public class FollowProfileDto {
     private final String nickname;
     private final String profileImage;
+
+    // Follow 객체를 매개변수로 받는 생성자
+    public FollowProfileDto(Follow follow) {
+        this.nickname = follow.getFollowingUser().getNickname(); // FollowingUser의 nickname
+        this.profileImage = follow.getFollowingUser().getProfileImage(); // FollowingUser의 profileImage
+    }
+
 }

--- a/src/main/java/com/walking/project_walking/domain/userdto/UserDetailDto.java
+++ b/src/main/java/com/walking/project_walking/domain/userdto/UserDetailDto.java
@@ -8,11 +8,10 @@ import java.util.List;
 
 @Getter
 @Setter
-@NoArgsConstructor
 @AllArgsConstructor
 public class UserDetailDto {
-    private String nickname;
-    private String profileImage;
-    private List<FollowProfileDto> followers;
-    private List<FollowProfileDto> following;
+    private final String nickname;
+    private final String profileImage;
+    private final Long followerCount;
+    private final Long followingCount;
 }

--- a/src/main/java/com/walking/project_walking/domain/userdto/UserPageDto.java
+++ b/src/main/java/com/walking/project_walking/domain/userdto/UserPageDto.java
@@ -11,17 +11,16 @@ import java.util.List;
 
 @Getter
 @Setter
-@NoArgsConstructor
 @AllArgsConstructor
 public class UserPageDto {
-    private String nickname;
-    private String email;
-    private String name;
-    private String profileImage;
-    private List<FollowProfileDto> followers;
-    private List<FollowProfileDto> following;
+    private final String nickname;
+    private final String email;
+    private final String name;
+    private final String profileImage;
+    private final Long followers;
+    private final Long following;
 
-    public UserPageDto(Users user, List<FollowProfileDto> followers, List<FollowProfileDto> following) {
+    public UserPageDto(Users user, Long followers, Long following) {
         this.nickname = user.getNickname();
         this.email = user.getEmail();
         this.name = user.getName();

--- a/src/main/java/com/walking/project_walking/repository/FollowRepository.java
+++ b/src/main/java/com/walking/project_walking/repository/FollowRepository.java
@@ -5,6 +5,7 @@ import com.walking.project_walking.domain.followdto.FollowProfileDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,15 +13,17 @@ import java.util.List;
 @Repository
 public interface FollowRepository extends JpaRepository<Follow, Long> {
     // 헷갈림 주의, followingUser -> 팔로우 당하는 사용자 / followUser -> 팔로우 하는 사용자
-    // todo 경로 쓰는 것 말고 새로운 방법 검색해보기 왜이래
-    @Query("SELECT new com.walking.project_walking.domain.followdto.FollowProfileDto" +
-            "(f.followingUser.nickname, f.followingUser.profileImage) " +
-            "FROM Follow f WHERE f.followUser.userId = :followerId")
-    List<FollowProfileDto> findFollowingByFollowerId(Long followerId);
+    @Query("SELECT f FROM Follow f WHERE f.followUser.userId = :followerId")
+    List<Follow> findFollowingByFollowerId(Long followerId);
 
-    // 헷갈림 주의, followingUser -> 팔로우 당하는 사용자 / followUser -> 팔로우 하는 사용자
-    @Query("SELECT new com.walking.project_walking.domain.followdto.FollowProfileDto" +
-            "(f.followUser.nickname, f.followUser.profileImage) " +
-            "FROM Follow f WHERE f.followingUser.userId = :followingId")
-    List<FollowProfileDto> findFollowersByFollowingId(Long followingId);
+    @Query("SELECT f FROM Follow f WHERE f.followingUser.userId = :followingId")
+    List<Follow> findFollowersByFollowingId(Long followingId);
+
+    // 팔로잉 수 카운트
+    @Query("SELECT COUNT(f) FROM Follow f WHERE f.followUser.userId = :userId")
+    Long countFollowing(Long userId);
+
+    // 팔로워 수 카운트
+    @Query("SELECT COUNT(f) FROM Follow f WHERE f.followingUser.userId = :userId")
+    Long countFollowers(Long userId);
 }

--- a/src/main/java/com/walking/project_walking/repository/MyGoodsRepository.java
+++ b/src/main/java/com/walking/project_walking/repository/MyGoodsRepository.java
@@ -4,8 +4,12 @@ import com.walking.project_walking.domain.MyGoods;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface MyGoodsRepository extends JpaRepository<MyGoods, Long> {
     Boolean existsByUserIdAndGoodsId(Long userId, Long goodsId);
     MyGoods findByUserIdAndGoodsId(Long userId, Long goodsId);
+
+    List<MyGoods> findByUserId(Long userId);
 }

--- a/src/main/java/com/walking/project_walking/service/FollowService.java
+++ b/src/main/java/com/walking/project_walking/service/FollowService.java
@@ -37,14 +37,14 @@ public class FollowService {
     }
 
     // 팔로우 조회 (현재 사용자의 팔로잉 목록)
-    public List<FollowProfileDto> getFollowing(Long userId) {
+    public List<Follow> getFollowing(Long userId) {
         Users users = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
         return followRepository.findFollowingByFollowerId(userId);
     }
 
     // 팔로워 조회 (현재 사용자의 팔로워 목록)
-    public List<FollowProfileDto> getFollower(Long userId) {
+    public List<Follow> getFollower(Long userId) {
         Users users = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
         return followRepository.findFollowersByFollowingId(userId);

--- a/src/main/java/com/walking/project_walking/service/UserService.java
+++ b/src/main/java/com/walking/project_walking/service/UserService.java
@@ -1,12 +1,14 @@
 package com.walking.project_walking.service;
 
 import com.walking.project_walking.domain.Follow;
+import com.walking.project_walking.domain.MyGoods;
 import com.walking.project_walking.domain.PointLog;
 import com.walking.project_walking.domain.Users;
 import com.walking.project_walking.domain.followdto.FollowProfileDto;
 import com.walking.project_walking.domain.userdto.*;
 
 import com.walking.project_walking.repository.FollowRepository;
+import com.walking.project_walking.repository.MyGoodsRepository;
 import com.walking.project_walking.repository.PointLogRepository;
 import com.walking.project_walking.repository.UserRepository;
 import jakarta.transaction.Transactional;
@@ -26,6 +28,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final FollowRepository followRepository;
     private final PointLogRepository pointLogRepository;
+    private final MyGoodsRepository myGoodsRepository;
 
     @Transactional
     public Users saveUser(UserSignUpDto dto) {
@@ -116,6 +119,15 @@ public class UserService {
     // 사용자 포인트 조회 서비스
     public List<PointLog> getPointLog(Long userId) {
         return pointLogRepository.findByUserId(userId);
+    }
+
+    // 사용자 아이템 조회 서비스
+    public List<MyGoods> getGoods(Long userId) {
+        List<MyGoods> myGoods = myGoodsRepository.findByUserId(userId);
+        if (myGoods.isEmpty()) {
+            throw new IllegalArgumentException("등록된 아이템이 없습니다.");
+        }
+        return myGoods;
     }
 
 

--- a/src/main/java/com/walking/project_walking/service/UserService.java
+++ b/src/main/java/com/walking/project_walking/service/UserService.java
@@ -1,5 +1,6 @@
 package com.walking.project_walking.service;
 
+import com.walking.project_walking.domain.Follow;
 import com.walking.project_walking.domain.PointLog;
 import com.walking.project_walking.domain.Users;
 import com.walking.project_walking.domain.followdto.FollowProfileDto;
@@ -95,10 +96,10 @@ public class UserService {
         Users user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
 
-        List<FollowProfileDto> followers = followRepository.findFollowersByFollowingId(userId);
-        List<FollowProfileDto> following = followRepository.findFollowingByFollowerId(userId);
+        Long followerCount = followRepository.countFollowers(userId);
+        Long followingCount = followRepository.countFollowing(userId);
 
-        return new UserDetailDto(user.getNickname(), user.getProfileImage(), followers, following);
+        return new UserDetailDto(user.getNickname(), user.getProfileImage(), followerCount, followingCount);
     }
 
     // mypage에서 정보 반환
@@ -106,10 +107,10 @@ public class UserService {
         Users users = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
 
-        List<FollowProfileDto> followers = followRepository.findFollowersByFollowingId(userId);
-        List<FollowProfileDto> following = followRepository.findFollowingByFollowerId(userId);
+        Long followerCount = followRepository.countFollowers(userId);
+        Long followingCount = followRepository.countFollowing(userId);
 
-        return new UserPageDto(users, followers, following);
+        return new UserPageDto(users, followerCount, followingCount);
     }
 
     // 사용자 포인트 조회 서비스


### PR DESCRIPTION
#기존 팔로우, 팔로워 조회
- DTO로 변환한 값으로 DB에서 조회
수정 내역 : 컨트롤러에서 Dto 처리

#아이템 조회 기능 추가

#최근 본 게시글 기능 추가
- (이슈) DB에 user_id가 unique 타입이 아니라 한 유저가 여러 개의 게시글을 저장할 수 있음 
-> 회의 후 unique 설정을 할지, 최대 갯수를 지정할지 정해야 함

- 게시글 상세보기 페이지가 완성되지 않아 최근 게시글을 추가하는 로직은 아직 적용하지 않음