### PR TITLE
관리자 View 추가 및 일부 기능 구현

### DIFF
--- a/src/main/java/com/walking/project_walking/controller/AdminController.java
+++ b/src/main/java/com/walking/project_walking/controller/AdminController.java
@@ -40,15 +40,15 @@ public class AdminController {
     }
 
     @PostMapping("/boards")
-    public ResponseEntity<String> addBoard(@RequestBody Board board) {
+    public ResponseEntity<Board> addBoard(@RequestBody Board board) {
         Board newBoard = boardService.addBoard(board);
-        return ResponseEntity.ok().body(newBoard.getName() + " 게시판이 생성 되었습니다.");
+        return ResponseEntity.status(HttpStatus.CREATED).body(newBoard);
     }
 
     @DeleteMapping("/boards/{boardId}")
     public ResponseEntity<String> deleteBoard(@PathVariable Long boardId) {
         Board board = boardService.getBoard(boardId);
-        if (board.getBoardId() == null) {
+        if (board == null) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("해당하는 ID를 가진 게시판이 없습니다.");
         }
         boardService.deleteBoard(board.getBoardId());
@@ -58,7 +58,7 @@ public class AdminController {
     @PutMapping("/boards/{boardId}")
     public ResponseEntity<String> updateBoard(@PathVariable Long boardId, @RequestBody Board board) {
         Board orgBoard = boardService.getBoard(boardId);
-        if (orgBoard.getBoardId() == null) {
+        if (orgBoard == null) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("해당하는 ID를 가진 게시판이 없습니다.");
         }
         boardService.updateBoard(board);

--- a/src/main/java/com/walking/project_walking/controller/AdminViewController.java
+++ b/src/main/java/com/walking/project_walking/controller/AdminViewController.java
@@ -20,7 +20,8 @@ public class AdminViewController {
     private final BoardService boardService;
 
     @GetMapping
-    public String adminView() {
+    public String adminView(Model model) {
+        model.addAttribute("user", userService.findById(2L)); // 테스트용, 삭제 필요
         return "admin";
     }
 

--- a/src/main/resources/static/css/bootstrap-addon.css
+++ b/src/main/resources/static/css/bootstrap-addon.css
@@ -1,0 +1,6 @@
+@media (min-width: 992px) {
+  .dropdown:hover .dropdown-menu {
+    display: block;
+    top: 95%;
+  }
+}

--- a/src/main/resources/static/js/admin-page.js
+++ b/src/main/resources/static/js/admin-page.js
@@ -1,0 +1,38 @@
+$(window).on('load', function() {
+  $.ajax({
+    url: '/admin/users',
+    method: 'GET',
+    success: function(data) {
+      $('#data').html(data);
+    }
+  });
+
+  const manage_user = document.getElementById('manage-user');
+  const manage_board = document.getElementById('manage-board');
+
+  manage_user.addEventListener('click', function() {
+    $.ajax({
+      url: '/admin/users',
+      method: 'GET',
+      success: function(data) {
+        $('#data').html(data);
+      },
+      error: function(xhr, status, error) {
+        $('#data').html('Error: ' + error);
+      }
+    });
+  });
+
+  manage_board.addEventListener('click', function() {
+    $.ajax({
+      url: '/admin/board',
+      method: 'GET',
+      success: function(data) {
+        $('#data').html(data);
+      },
+      error: function(xhr, status, error) {
+        $('#data').html('Error: ' + error);
+      }
+    });
+  });
+});

--- a/src/main/resources/templates/admin.html
+++ b/src/main/resources/templates/admin.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+  <link th:href="@{/css/bootstrap-addon.css}" rel="stylesheet" />
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+</head>
+<body>
+<div>
+  <div class="d-flex">
+    <aside th:replace="~{/fragments/sidebar.html :: fragment-admin-sidebar(user=${user})}">TestAside</aside>
+    <span id="data" style="width: 100%">Loading...</span>
+  </div>
+</div>
+<script th:src="@{/js/admin-page.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/board.html
+++ b/src/main/resources/templates/board.html
@@ -1,31 +1,171 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>게시판 관리</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-</head>
-<body>
-<div>
+<div style="width: 100%;">
   <table class="table table-dark table-striped">
     <thead>
     <tr>
       <th scope="col">#</th>
       <th scope="col">게시판 이름</th>
       <th scope="col"></th>
-      <th scope="col"></th>
+      <th scope="col"><a href="#" class="btn btn-primary add-button">게시판 추가</a></th>
     </tr>
     </thead>
     <tbody>
     <tr th:each="board : ${boardList}">
       <td th:text="${board.getBoardId()}"></td>
       <td th:text="${board.getName()}"></td>
-      <td><a class="btn btn-success">수정</a></td>
-      <td><a class="btn btn-danger">삭제</a></td>
+      <td>
+        <a href="#" class="btn btn-success edit-button" th:data-board-id="${board.getBoardId()}">수정</a>
+      </td>
+      <td>
+        <a href="#" class="btn btn-danger delete-button" th:data-board-id="${board.getBoardId()}">삭제</a>
+      </td>
     </tr>
     </tbody>
   </table>
 </div>
-</body>
-</html>
+
+<div class="modal fade" id="editModal" tabindex="-1" aria-labelledby="editModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="editModalLabel">수정하기</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <input type="text" id="editBoardName" class="form-control" placeholder="새 게시판의 이름을 입력하세요">
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
+        <button type="button" class="btn btn-primary" id="saveChanges">저장</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="deleteModal" tabindex="-1" aria-labelledby="deleteModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="deleteModalLabel">게시판 삭제 확인</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        정말로 게시판을 삭제 하시겠습니까?
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
+        <button type="button" class="btn btn-danger" id="confirmDelete">삭제</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="addModal" tabindex="-1" aria-labelledby="addModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="addModalLabel">게시판 추가</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label for="newBoardName" class="form-label">게시판 이름</label>
+          <input type="text" class="form-control" id="newBoardName" required>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
+        <button type="button" class="btn btn-primary" id="addBoard">추가하기</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  $(document).ready(function() {
+    let currentBoardId;
+
+    $(document).on('click', '.edit-button', function(e) {
+      e.preventDefault();
+      currentBoardId = $(this).data('board-id');
+
+      $('#editBoardName').val($(this).closest('tr').find('td:nth-child(2)').text());
+      $('#editModal').modal('show');
+    });
+
+    $('#saveChanges').on('click', function() {
+      const newName = $('#editBoardName').val();
+
+      $.ajax({
+        url: '/api/admin/boards/' + currentBoardId,
+        method: 'PUT',
+        contentType: 'application/json',
+        data: JSON.stringify({ boardId: currentBoardId, name: newName }),
+        success: function() {
+          $('#editModal').modal('hide');
+
+          const row = $('tr').filter(function() {
+            return $(this).find('.edit-button').data('board-id') === currentBoardId;
+          });
+
+          row.find('td:nth-child(2)').text(newName);
+        },
+        error: function(xhr, status, error) {
+          console.error('수정 오류:', error);
+        }
+      });
+    });
+  });
+
+  $(document).on('click', '.delete-button', function(e) {
+    e.preventDefault();
+    currentBoardId = $(this).data('board-id');
+    $('#deleteModal').modal('show');
+  });
+
+  $('#confirmDelete').on('click', function() {
+    $.ajax({
+      url: '/api/admin/boards/' + currentBoardId,
+      method: 'DELETE',
+      success: function() {
+        $('tr').has('a[data-board-id="' + currentBoardId + '"]').remove();
+        $('#deleteModal').modal('hide');
+      },
+      error: function(xhr, status, error) {
+        console.error('삭제 오류:', error);
+      }
+    });
+  });
+
+  $(document).on('click', '.add-button', function(e) {
+    e.preventDefault();
+    $('#addModal').modal('show');
+  });
+
+  $('#addBoard').on('click', function() {
+    const newBoardName = $('#newBoardName').val();
+
+    $.ajax({
+      url: '/api/admin/boards',
+      method: 'POST',
+      contentType: 'application/json',
+      data: JSON.stringify({ name: newBoardName }),
+      success: function(response) {
+        $('#addModal').modal('hide');
+
+        const newRow = `
+        <tr>
+          <td>${response.boardId}</td>
+          <td>${newBoardName}</td>
+          <td><a href="#" class="btn btn-success edit-button" data-board-id="${response.boardId}">수정</a></td>
+          <td><a href="#" class="btn btn-danger delete-button" data-board-id="${response.boardId}">삭제</a></td>
+        </tr>`;
+
+        $('table tbody').append(newRow);
+      },
+      error: function(xhr, status, error) {
+        console.error('추가 오류:', error);
+      }
+    });
+  });
+
+</script>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -1,0 +1,49 @@
+<div th:fragment="fragment-header">
+  <nav class="navbar sticky-top navbar-expand-lg bg-body-tertiary">
+    <div class="container-fluid">
+      <a class="navbar-brand" href="#">Project Icon</a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNavDropdown">
+        <ul class="navbar-nav">
+          <li class="nav-item">
+            <a class="nav-link active" aria-current="page" href="#">홈</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#">포인트 상점</a>
+          </li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              게시판
+            </a>
+            <ul class="dropdown-menu">
+              <li><a class="dropdown-item" href="#">걷기 인증 게시판</a></li>
+              <li><a class="dropdown-item" href="#">자유 게시판</a></li>
+            </ul>
+          </li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              문의하기
+            </a>
+            <ul class="dropdown-menu">
+              <li><a class="dropdown-item" href="#">1대1 문의</a></li>
+              <li><a class="dropdown-item" href="#">자주 묻는 질문</a></li>
+            </ul>
+          </li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              Test님 반갑습니다!
+            </a>
+            <ul class="dropdown-menu">
+              <li><a class="dropdown-item disabled" href="#">내 포인트: 5000</a></li>
+              <li><hr class="dropdown-divider"></li>
+              <li><a class="dropdown-item" href="#">마이 페이지</a></li>
+              <li><a class="dropdown-item" href="#">로그아웃</a></li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+</div>

--- a/src/main/resources/templates/fragments/sidebar.html
+++ b/src/main/resources/templates/fragments/sidebar.html
@@ -1,0 +1,29 @@
+<div class="d-flex flex-column flex-shrink-0 p-3 text-white bg-dark" style="width: 280px; height: 100dvh; overflow: hidden;" th:fragment="fragment-admin-sidebar">
+  <a href="#" class="d-flex align-items-center mb-3 mb-md-0 me-md-auto text-white text-decoration-none">
+    <svg class="bi me-2" width="40" height="32"><use xlink:href="#bootstrap"></use></svg>
+    <span class="fs-4">관리자 메뉴</span>
+  </a>
+  <hr>
+  <ul class="nav nav-pills flex-column mb-auto">
+    <li>
+      <a href="#" class="nav-link text-white" id="manage-user">
+        유저 관리
+      </a>
+    </li>
+    <li>
+      <a href="#" class="nav-link text-white" id="manage-board">
+        게시판 관리
+      </a>
+    </li>
+  </ul>
+  <hr>
+  <div class="d-flex column-gap-5 justify-content-between">
+    <a href="#" class="d-flex align-items-center text-white text-decoration-none">
+      <img src="https://placehold.co/32x32" alt="" width="32" height="32" class="rounded-circle me-2">
+      <strong th:text="${user.getNickname()}"></strong>
+    </a>
+    <a href="#" class="d-flex align-items-center text-white text-decoration-none" >
+      로그아웃
+    </a>
+  </div>
+</div>

--- a/src/main/resources/templates/user.html
+++ b/src/main/resources/templates/user.html
@@ -1,74 +1,55 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>유저 상세 정보</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-</head>
-<body>
-<section class="h-100 gradient-custom-2">
-  <div class="container py-5 h-100">
-    <div class="row d-flex justify-content-center">
-      <div class="col col-lg-9 col-xl-8">
-        <div class="card">
-          <div class="rounded-top text-white d-flex flex-row" style="background-color: #000; height:200px;">
-            <div class="ms-4 mt-5 d-flex flex-column" style="width: 150px;">
-              <img src="https://placehold.co/150x150"
-                   alt="Generic placeholder image" class="img-fluid img-thumbnail mt-4 mb-2"
-                   style="width: 150px; z-index: 1">
-            </div>
-            <div class="ms-3" style="margin-top: 130px;">
-              <h5>[[${user.getNickname()}]] ([[${user.getGender()} ? '남' : '여']])</h5>
-              <p th:text="${user.getName()}"></p>
-            </div>
-          </div>
-          <div class="p-4 text-black bg-body-tertiary">
-            <div class="d-flex justify-content-end text-center py-1 text-body">
-              <div class="px-3">
-                <p class="small text-muted mb-0">레벨</p>
-                <p class="mb-1 h5">0</p>
-              </div>
-              <div class="px-3">
-                <p class="small text-muted mb-0">경험치</p>
-                <p class="mb-1 h5">0</p>
-              </div>
-              <div class="px-3">
-                <p class="small text-muted mb-0">포인트</p>
-                <p class="mb-1 h5">0</p>
-              </div>
-              <div class="px-3">
-                <p class="small text-muted mb-0">게시물 수</p>
-                <p class="mb-1 h5">0</p>
-              </div>
-              <div class="px-3">
-                <p class="small text-muted mb-0">팔로워 수</p>
-                <p class="mb-1 h5">0</p>
-              </div>
-              <div>
-                <p class="small text-muted mb-0">팔로잉한 유저 수</p>
-                <p class="mb-1 h5">0</p>
-              </div>
-            </div>
-          </div>
-          <div class="card-body p-4 text-black">
-            <div class="mb-5  text-body">
-              <p class="lead fw-normal mb-1">상세 정보</p>
-              <div class="p-4 bg-body-tertiary">
-                <p class="font-italic mb-1">이메일: [[${user.getEmail()}]]</p>
-                <p class="font-italic mb-1">전화번호: [[${user.getPhone()}]]</p>
-                <p class="font-italic mb-1">생일: [[${user.getBirth()}]]</p>
-                <p class="font-italic mb-1">가입일: [[${user.getJoinDate()}]]</p>
-                <p class="font-italic mb-1">최근 로그인: [[${user.getLastLogin()}]]</p>
-                <p class="font-italic mb-1">로그인 횟수: [[${user.getLoginCount()}]]</p>
-                <p class="font-italic mb-1">접속 브라우저 정보: [[${user.getLoginBrowser()}]]</p>
-                <p class="font-italic mb-0">계정 활성화 여부: [[${user.getIsActive()}]]</p>
-              </div>
-            </div>
-          </div>
-        </div>
+<div class="card">
+  <div class="rounded-top text-white d-flex flex-row" style="background-color: #000; height:200px;">
+    <div class="ms-4 mt-5 d-flex flex-column" style="width: 150px;">
+      <img src="https://placehold.co/150x150"
+           alt="Generic placeholder image" class="img-fluid img-thumbnail mt-4 mb-2"
+           style="width: 150px; z-index: 1">
+    </div>
+    <div class="ms-3" style="margin-top: 130px;">
+      <h5>[[${user.getNickname()}]] ([[${user.getGender()} ? '남' : '여']])</h5>
+      <p th:text="${user.getName()}"></p>
+    </div>
+  </div>
+  <div class="p-4 text-black bg-body-tertiary">
+    <div class="d-flex justify-content-end text-center py-1 text-body">
+      <div class="px-3">
+        <p class="small text-muted mb-0">레벨</p>
+        <p class="mb-1 h5" th:text="${user.getUserLevel()}"></p>
+      </div>
+      <div class="px-3">
+        <p class="small text-muted mb-0">경험치</p>
+        <p class="mb-1 h5" th:text="${user.getUserExp()}"></p>
+      </div>
+      <div class="px-3">
+        <p class="small text-muted mb-0">포인트</p>
+        <p class="mb-1 h5" th:text="${user.getPoint()}"></p>
+      </div>
+      <div class="px-3">
+        <p class="small text-muted mb-0">게시물 수</p>
+        <p class="mb-1 h5">0</p>
+      </div>
+      <div class="px-3">
+        <p class="small text-muted mb-0">팔로워 수</p>
+        <p class="mb-1 h5">0</p>
+      </div>
+      <div>
+        <p class="small text-muted mb-0">팔로잉한 유저 수</p>
+        <p class="mb-1 h5">0</p>
       </div>
     </div>
   </div>
-</section>
-</body>
-</html>
+  <div class="card-body p-4 text-black">
+    <div class="mb-5  text-body">
+      <p class="lead fw-normal mb-1">상세 정보</p>
+      <div class="p-4 bg-body-tertiary">
+        <p class="font-italic mb-1">이메일: [[${user.getEmail()}]]</p>
+        <p class="font-italic mb-1">전화번호: [[${user.getPhone()}]]</p>
+        <p class="font-italic mb-1">생일: [[${user.getBirth()}]]</p>
+        <p class="font-italic mb-1">가입일: [[${user.getJoinDate()}]]</p>
+        <p class="font-italic mb-1">최근 로그인: [[${user.getLastLogin()}]]</p>
+        <p class="font-italic mb-1">로그인 횟수: [[${user.getLoginCount()}]]</p>
+        <p class="font-italic mb-1">접속 브라우저 정보: [[${user.getLoginBrowser()}]]</p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/main/resources/templates/users.html
+++ b/src/main/resources/templates/users.html
@@ -1,56 +1,78 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>유저 관리 페이지</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-</head>
-<body>
-<div>
+<div style="width: 100%;">
   <table class="table table-dark table-striped">
     <thead>
-      <tr>
-        <th scope="col">#</th>
-        <th scope="col" class="text-center">이메일</th>
-        <th scope="col" class="text-center">이름</th>
-        <th scope="col" class="text-center">전화번호</th>
-        <th scope="col" class="text-center">닉네임</th>
-        <th scope="col" class="text-center">성별</th>
-        <th scope="col" class="text-center">생일</th>
-        <th scope="col" class="text-center">가입일</th>
-        <th scope="col" class="text-center">최근 로그인</th>
-        <th scope="col" class="text-center">로그인 횟수</th>
-        <th scope="col" class="text-center">레벨</th>
-        <th scope="col" class="text-center">경험치</th>
-        <th scope="col" class="text-center">포인트</th>
-        <th scope="col" class="text-center">계정 활성화 여부</th>
-        <th scope="col"></th>
-        <th scope="col"></th>
-        <th scope="col"></th>
-      </tr>
+    <tr>
+      <th scope="col">#</th>
+      <th scope="col" class="text-center">이메일</th>
+      <th scope="col" class="text-center">이름</th>
+      <th scope="col" class="text-center">전화번호</th>
+      <th scope="col" class="text-center">닉네임</th>
+      <th scope="col" class="text-center">성별</th>
+      <th scope="col" class="text-center">생일</th>
+      <th scope="col" class="text-center">가입일</th>
+      <th scope="col" class="text-center">최근 로그인</th>
+      <th scope="col" class="text-center">로그인 횟수</th>
+      <th scope="col" class="text-center">계정 활성화 여부</th>
+      <th scope="col"></th>
+      <th scope="col"></th>
+      <th scope="col"></th>
+    </tr>
     </thead>
     <tbody>
-      <tr th:each="user : ${userList}">
-        <td th:text="${user.getUserId()}"></td>
-        <td th:text="${user.getEmail()}"></td>
-        <td th:text="${user.getName()}"></td>
-        <td th:text="${user.getPhone()}"></td>
-        <td th:text="${user.getNickname()}"></td>
-        <td th:text="${user.getGender()} ? '남' : '여'"></td>
-        <td th:text="${user.getBirth()}"></td>
-        <td th:text="${user.getJoinDate()}"></td>
-        <td th:text="${user.getLastLogin()}"></td>
-        <td th:text="${user.getLoginCount()}"></td>
-        <td th:text="${user.getUserLevel()}"></td>
-        <td th:text="${user.getUserExp()}"></td>
-        <td th:text="${user.getPoint()}"></td>
-        <td th:text="${user.getIsActive()}"></td>
-        <td><a class="btn btn-primary" th:href="@{/admin/users/{userId}(userId=${user.getUserId()})}">자세히</a></td>
-        <td><a class="btn btn-success">수정</a></td>
-        <td><a class="btn btn-danger">삭제</a></td>
-      </tr>
+    <tr th:each="user : ${userList}">
+      <td th:text="${user.getUserId()}"></td>
+      <td th:text="${user.getEmail()}"></td>
+      <td th:text="${user.getName()}"></td>
+      <td th:text="${user.getPhone()}"></td>
+      <td th:text="${user.getNickname()}"></td>
+      <td th:text="${user.getGender()} ? '남' : '여'"></td>
+      <td th:text="${user.getBirth()}"></td>
+      <td th:text="${user.getJoinDate()}"></td>
+      <td th:text="${user.getLastLogin()}"></td>
+      <td th:text="${user.getLoginCount()}"></td>
+      <td th:text="${user.getIsActive()} ? '활성화' : '비활성화'"></td>
+      <td>
+        <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#userModal"
+                th:data-user-id="${user.getUserId()}">자세히</button>
+      </td>
+      <td><a class="btn btn-success">수정</a></td>
+      <td><a class="btn btn-danger">삭제</a></td>
+    </tr>
     </tbody>
   </table>
 </div>
-</body>
-</html>
+
+<div class="modal fade" id="userModal" tabindex="-1" aria-labelledby="userModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div id="modalContent">
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">닫기</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  $('#userModal').on('show.bs.modal', function(event) {
+    const button = $(event.relatedTarget);
+    const userId = button.data('user-id');
+
+    $.ajax({
+      url: '/admin/users/' + userId,
+      method: 'GET',
+      success: function(data) {
+        $('#modalContent').html(data);
+      },
+      error: function(xhr, status, error) {
+        $('#modalContent').html('<p class="text-danger">오류: ' + error + '</p>');
+      }
+    });
+  });
+</script>


### PR DESCRIPTION
#### AdminController.java
* 생성된 게시판의 id를 뷰에서 가져와야 해서, `@PostMapping("/boards")` 의 리턴 형태를 변경하였습니다.
* 엔티티가 없다면 null을 반환하기에 처리 로직을 변경하였습니다.

#### AdminViewController.java
* 유저의 데이터를 잘 받아오는지 테스트하기 위해 테스트용 유저를 모델에 추가하였습니다.

#### admin-page.js
* 관리자 페이지 사이드바에서 메인 페이지의 콘텐츠 영역에 데이터를 넣는 js입니다.

#### admin.html
* 관리자 메인 페이지 입니다. 콘텐츠 영역 100% 비동기를 목표로 하고있습니다.
* TODO: 페이지 내의 사이드바가 fragment로 사용되는데, 단 하나의 페이지에서만 사용되어 fragment로 사용해야 하는지 잘 모르겠습니다.

#### board.html, header.html, sidebar.html, user.html, users.html
* 비동기에 필요한 페이지들 입니다.