### PR TITLE
구조변경 및 버그 수정

### DIFF
--- a/src/main/java/com/walking/project_walking/controller/BoardController.java
+++ b/src/main/java/com/walking/project_walking/controller/BoardController.java
@@ -49,6 +49,10 @@ public class BoardController {
         PageRequest pageRequest = PageRequest.of(page - 1, PAGE_SIZE);
         List<PostResponseDto> postsList = postsService.getPostsByBoardId(boardId, pageRequest);
 
+        if (postsList.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NO_CONTENT).build(); // 204 No Content
+        }
+
         return ResponseEntity.ok(postsList);
     }
 

--- a/src/main/java/com/walking/project_walking/controller/BoardController.java
+++ b/src/main/java/com/walking/project_walking/controller/BoardController.java
@@ -1,6 +1,7 @@
 package com.walking.project_walking.controller;
 
 import com.walking.project_walking.domain.dto.BoardResponseDto;
+import com.walking.project_walking.domain.dto.NoticeResponseDto;
 import com.walking.project_walking.domain.dto.PostResponseDto;
 import com.walking.project_walking.service.BoardService;
 import com.walking.project_walking.service.PostsService;
@@ -33,7 +34,7 @@ public class BoardController {
         return ResponseEntity.ok(boardList);
     }
 
-    // 특정 게시판, 특정 페이지의 게시글 조회(공지사항 포함)
+    // 특정 게시판, 특정 페이지의 게시글 조회
     @GetMapping("/posts")
     public ResponseEntity<List<PostResponseDto>> getPostsByBoard(
             @RequestParam Long boardId,
@@ -49,6 +50,18 @@ public class BoardController {
         List<PostResponseDto> postsList = postsService.getPostsByBoardId(boardId, pageRequest);
 
         return ResponseEntity.ok(postsList);
+    }
+
+    // 공지사항 조회
+    @GetMapping("/notices")
+    public ResponseEntity<List<NoticeResponseDto>> getNoticesByBoard(){
+        PageRequest pageRequest = PageRequest.of(0, 2);
+        List<NoticeResponseDto> noticesList = postsService.getNoticePosts(pageRequest);
+
+        if (noticesList.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        }
+        return ResponseEntity.ok(noticesList);
     }
 
     // 특정 게시판의 페이지 갯수 조회

--- a/src/main/java/com/walking/project_walking/controller/PostsController.java
+++ b/src/main/java/com/walking/project_walking/controller/PostsController.java
@@ -1,6 +1,7 @@
 package com.walking.project_walking.controller;
 
 import com.walking.project_walking.domain.dto.PostResponseDto;
+import com.walking.project_walking.domain.dto.PostSearchResultDto;
 import com.walking.project_walking.domain.dto.PostSummuryResponseDto;
 import com.walking.project_walking.service.BoardService;
 import com.walking.project_walking.service.PostsService;
@@ -25,7 +26,7 @@ public class PostsController {
 
     // 제목, 글쓴이, 내용을 조합하여 특정 게시글 조회
     @GetMapping("/search")
-    public ResponseEntity<List<PostResponseDto>> searchPosts(
+    public ResponseEntity<PostSearchResultDto> searchPosts(
             @RequestParam Long boardId,
             @RequestParam(required = false) String title,
             @RequestParam(required = false) String content,
@@ -37,9 +38,9 @@ public class PostsController {
                     .build();
         }
 
-        int board_page = boardService.getPageCount(boardId);
+        int totalPages = postsService.getTotalPages(boardId, title, content, nickname, PAGE_SIZE);
 
-        if (page < 1 || page > board_page) {
+        if (page < 1 || page > totalPages) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
         }
 
@@ -49,8 +50,8 @@ public class PostsController {
         if (postList.isEmpty()) {
             return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
         }
-
-        return ResponseEntity.ok(postList);
+        PostSearchResultDto result = new PostSearchResultDto(postList, totalPages);
+        return ResponseEntity.ok(result);
     }
 
     // 인기 게시판 전용

--- a/src/main/java/com/walking/project_walking/controller/PostsController.java
+++ b/src/main/java/com/walking/project_walking/controller/PostsController.java
@@ -38,18 +38,18 @@ public class PostsController {
                     .build();
         }
 
-        int totalPages = postsService.getTotalPages(boardId, title, content, nickname, PAGE_SIZE);
-
-        if (page < 1 || page > totalPages) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
-        }
-
         PageRequest pageRequest = PageRequest.of(page - 1, PAGE_SIZE);
         List<PostResponseDto> postList = postsService.searchPosts(boardId, title, content, nickname, pageRequest);
 
         if (postList.isEmpty()) {
             return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
         }
+        int totalPages = postsService.getTotalPages(boardId, title, content, nickname, PAGE_SIZE);
+
+        if (page < 1 || page > totalPages) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+
         PostSearchResultDto result = new PostSearchResultDto(postList, totalPages);
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/com/walking/project_walking/domain/dto/NoticeResponseDto.java
+++ b/src/main/java/com/walking/project_walking/domain/dto/NoticeResponseDto.java
@@ -1,0 +1,23 @@
+package com.walking.project_walking.domain.dto;
+
+import com.walking.project_walking.domain.Posts;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class NoticeResponseDto {
+    private Long postId;
+    private String title;
+    private String content;
+    private LocalDateTime createdAt;
+
+    public static NoticeResponseDto fromEntity(Posts post){
+        NoticeResponseDto dto = new NoticeResponseDto();
+        dto.postId = post.getPostId();
+        dto.title = post.getTitle();
+        dto.content = post.getContent();
+        dto.createdAt = post.getCreatedAt();
+        return dto;
+    }
+}

--- a/src/main/java/com/walking/project_walking/domain/dto/PostResponseDto.java
+++ b/src/main/java/com/walking/project_walking/domain/dto/PostResponseDto.java
@@ -14,9 +14,9 @@ public class PostResponseDto {
     private String content;
     private Integer viewCount;
     private Integer likes;
-    private Long userId;
+    private String nickname;
 
-    public static PostResponseDto fromEntity(Posts post, Integer commentsNumber) {
+    public static PostResponseDto fromEntity(Posts post, Integer commentsNumber, String nickname) {
         PostResponseDto dto = new PostResponseDto();
         dto.boardId = post.getBoardId();
         dto.createdAt = post.getCreatedAt();
@@ -26,7 +26,7 @@ public class PostResponseDto {
         dto.content = post.getContent();
         dto.viewCount = post.getViewCount();
         dto.likes = post.getLikes();
-        dto.userId = post.getUserId();
+        dto.nickname = nickname;
         return dto;
     }
 

--- a/src/main/java/com/walking/project_walking/domain/dto/PostSearchResultDto.java
+++ b/src/main/java/com/walking/project_walking/domain/dto/PostSearchResultDto.java
@@ -1,0 +1,16 @@
+package com.walking.project_walking.domain.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class PostSearchResultDto {
+    private List<PostResponseDto> posts;
+    private int totalPages;
+
+    public PostSearchResultDto(List<PostResponseDto> posts, int totalPages) {
+        this.posts = posts;
+        this.totalPages = totalPages;
+    }
+}

--- a/src/main/java/com/walking/project_walking/repository/PostsRepository.java
+++ b/src/main/java/com/walking/project_walking/repository/PostsRepository.java
@@ -24,4 +24,13 @@ public interface PostsRepository extends JpaRepository<Posts, Long> {
     List<Posts> findHotPosts(@Param("threshold") double threshold);
 
     List<Posts> findByUserId(Long userId);
+
+    @Query("SELECT COUNT(p) FROM Posts p WHERE p.boardId = :boardId AND " +
+            "(:title IS NULL OR p.title LIKE %:title%) AND " +
+            "(:content IS NULL OR p.content LIKE %:content%) AND " +
+            "(:userId IS NULL OR p.userId = :userId)")
+    long countBySearchCriteria(@Param("boardId") Long boardId,
+                                @Param("title") String title,
+                                @Param("content") String content,
+                                @Param("userId") Long userId);
 }

--- a/src/main/java/com/walking/project_walking/repository/UserRepository.java
+++ b/src/main/java/com/walking/project_walking/repository/UserRepository.java
@@ -14,4 +14,7 @@ public interface UserRepository extends JpaRepository<Users, Long> {
 
     @Query("SELECT u.userId FROM Users u WHERE u.nickname = :nickname")
     Long getUserIdByNickname(@Param("nickname") String nickname);
+
+    @Query("SELECT u.nickname FROM Users u WHERE u.userId = :userId")
+    String getNicknameByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/walking/project_walking/service/PostsService.java
+++ b/src/main/java/com/walking/project_walking/service/PostsService.java
@@ -33,7 +33,8 @@ public class PostsService {
             List<Posts> topPosts = postsRepository.findByBoardId(1L, PageRequest.of(0, 2)).getContent();
             for (Posts post : topPosts) {
                 Integer commentsNumber = commentsRepository.countCommentsByPostId(post.getPostId());
-                result.add(PostResponseDto.fromEntity(post, commentsNumber));
+                String postNickname = userRepository.getNicknameByUserId(post.getUserId());
+                result.add(PostResponseDto.fromEntity(post, commentsNumber, postNickname));
             }
         }
 
@@ -41,7 +42,8 @@ public class PostsService {
         List<PostResponseDto> posts = postsRepository.findByBoardId(boardId, pageRequest)
                 .map(post -> {
                     Integer commentsNumber = commentsRepository.countCommentsByPostId(post.getPostId());
-                    return PostResponseDto.fromEntity(post, commentsNumber);
+                    String postNickname = userRepository.getNicknameByUserId(post.getUserId());
+                    return PostResponseDto.fromEntity(post, commentsNumber, postNickname);
                 }).toList();
 
         result.addAll(posts);
@@ -55,7 +57,8 @@ public class PostsService {
         return postsPage.getContent().stream()
                 .map(post -> {
                     Integer commentsNumber = commentsRepository.countCommentsByPostId(post.getPostId());
-                    return PostResponseDto.fromEntity(post, commentsNumber);
+                    String postNickname = userRepository.getNicknameByUserId(post.getUserId());
+                    return PostResponseDto.fromEntity(post, commentsNumber, postNickname);
                 })
                 .toList();
     }
@@ -66,7 +69,8 @@ public class PostsService {
         return hotPosts.stream()
                 .map(post -> {
                     Integer commentsNumber = commentsRepository.countCommentsByPostId(post.getPostId());
-                    return PostResponseDto.fromEntity(post, commentsNumber);
+                    String postNickname = userRepository.getNicknameByUserId(post.getUserId());
+                    return PostResponseDto.fromEntity(post, commentsNumber, postNickname);
                 })
                 .toList();
     }
@@ -80,7 +84,8 @@ public class PostsService {
                 .max(Comparator.comparing(Posts::getWeightValue))
                 .map(post -> {
                     Integer commentsNumber = commentsRepository.countCommentsByPostId(post.getPostId());
-                    return PostResponseDto.fromEntity(post, commentsNumber);
+                    String postNickname = userRepository.getNicknameByUserId(post.getUserId());
+                    return PostResponseDto.fromEntity(post, commentsNumber, postNickname);
                 })
                 .orElse(null);
     }

--- a/src/main/java/com/walking/project_walking/service/PostsService.java
+++ b/src/main/java/com/walking/project_walking/service/PostsService.java
@@ -12,10 +12,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -93,5 +91,11 @@ public class PostsService {
                     return PostSummuryResponseDto.fromEntity(post, commentsNumber);
                 })
                 .toList();
+    }
+
+    public int getTotalPages(Long boardId, String title, String content, String nickname, int pageSize) {
+        Long userId = userRepository.getUserIdByNickname(nickname);
+        long totalPosts = postsRepository.countBySearchCriteria(boardId, title, content, userId);
+        return (int) Math.ceil((double) totalPosts / pageSize);
     }
 }

--- a/src/main/java/com/walking/project_walking/service/PostsService.java
+++ b/src/main/java/com/walking/project_walking/service/PostsService.java
@@ -1,6 +1,7 @@
 package com.walking.project_walking.service;
 
 import com.walking.project_walking.domain.Posts;
+import com.walking.project_walking.domain.dto.NoticeResponseDto;
 import com.walking.project_walking.domain.dto.PostResponseDto;
 import com.walking.project_walking.domain.dto.PostSummuryResponseDto;
 import com.walking.project_walking.repository.CommentsRepository;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -26,28 +28,20 @@ public class PostsService {
 
     // 특정 게시판, 특정 페이지의 게시물을 가져오는 메소드 (가져오는 게시글 갯수는 6개로 정의)
     public List<PostResponseDto> getPostsByBoardId(Long boardId, PageRequest pageRequest) {
-        List<PostResponseDto> result = new ArrayList<>();
 
-        if (boardId != 1L) {
-            // boardId가 1인 게시글 2개를 먼저 추가
-            List<Posts> topPosts = postsRepository.findByBoardId(1L, PageRequest.of(0, 2)).getContent();
-            for (Posts post : topPosts) {
-                Integer commentsNumber = commentsRepository.countCommentsByPostId(post.getPostId());
-                String postNickname = userRepository.getNicknameByUserId(post.getUserId());
-                result.add(PostResponseDto.fromEntity(post, commentsNumber, postNickname));
-            }
-        }
-
-        // 특정 boardId의 게시글 추가
-        List<PostResponseDto> posts = postsRepository.findByBoardId(boardId, pageRequest)
+        return postsRepository.findByBoardId(boardId, pageRequest)
                 .map(post -> {
                     Integer commentsNumber = commentsRepository.countCommentsByPostId(post.getPostId());
                     String postNickname = userRepository.getNicknameByUserId(post.getUserId());
                     return PostResponseDto.fromEntity(post, commentsNumber, postNickname);
                 }).toList();
+    }
 
-        result.addAll(posts);
-        return result;
+    // 공지사항만 불러오는 메소드 (2개)
+    public List<NoticeResponseDto> getNoticePosts(PageRequest pageRequest) {
+        return postsRepository.findByBoardId(1L, pageRequest)
+                .map(NoticeResponseDto::fromEntity).toList();
+
     }
 
     // boardId와 제목, 내용, 글쓴이를 통해 특정 게시물을 조회하는 메소드

--- a/src/main/resources/static/css/board-list.css
+++ b/src/main/resources/static/css/board-list.css
@@ -1,0 +1,140 @@
+/* board-list.css */
+
+/* 기본 스타일 */
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: #f4f4f4;
+    color: #333;
+}
+
+/* 헤더 스타일 */
+header {
+    background-color: #4CAF50;
+    color: white;
+    padding: 15px 20px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+header div {
+    margin: 0 10px;
+}
+
+/* 사이드바 스타일 */
+.sidebar {
+    width: 200px;
+    background-color: #fff;
+    padding: 20px;
+    border-right: 1px solid #ccc;
+    position: fixed;
+    height: 100%;
+    overflow-y: auto;
+}
+
+.sidebar h3 {
+    margin-top: 0;
+    color: #4CAF50;
+}
+
+/* 메인 콘텐츠 스타일 */
+.main-content {
+    margin-left: 220px; /* 사이드바 너비 */
+    padding: 20px;
+}
+
+.popular-post, .recent-post {
+    background-color: #fff;
+    padding: 15px;
+    margin-bottom: 20px;
+    border-radius: 5px;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+.popular-post h3, .recent-post h3 {
+    margin-top: 0;
+    color: #4CAF50;
+}
+
+/* 검색 영역 스타일 */
+.search-bar {
+    margin-bottom: 20px;
+}
+
+.search-bar select, .search-bar input[type="text"], .search-bar button {
+    padding: 10px;
+    margin-right: 5px;
+}
+
+.search-bar input[type="text"] {
+    width: 200px;
+}
+
+.search-bar button {
+    background-color: #4CAF50;
+    color: white;
+    border: none;
+    cursor: pointer;
+    transition: background-color 0.3s;
+}
+
+.search-bar button:hover {
+    background-color: #45a049;
+}
+
+/* 공지사항 목록 스타일 */
+.notice-section {
+    margin-bottom: 20px;
+}
+
+.notice-section h4 {
+    margin-top: 0;
+}
+
+/* 게시글 목록 스타일 */
+#post-list li, #notice-list li {
+    margin-bottom: 10px;
+    padding: 10px;
+    background-color: #f9f9f9;
+    border: 1px solid #ddd;
+    border-radius: 5px;
+}
+
+#post-list h4, #notice-list h4 {
+    margin-top: 0;
+    color: #333;
+}
+
+/* 페이징 스타일 */
+.pagination {
+    margin-top: 20px;
+    text-align: center;
+}
+
+.pagination a {
+    margin: 0 5px;
+    padding: 8px 12px;
+    background-color: #4CAF50;
+    color: white;
+    border-radius: 5px;
+    text-decoration: none;
+}
+
+.pagination a:hover {
+    background-color: #45a049;
+}
+
+/* 반응형 스타일 */
+@media (max-width: 768px) {
+    .sidebar {
+        width: 100%;
+        position: relative;
+        border-right: none;
+    }
+
+    .main-content {
+        margin-left: 0;
+    }
+}

--- a/src/main/resources/static/js/board-list.js
+++ b/src/main/resources/static/js/board-list.js
@@ -1,0 +1,238 @@
+let currentPage = 1; // 현재 페이지 추적
+let pageCount = 0; // 총 페이지 수
+const pagesToShow = 10; // 한 번에 표시할 페이지 수
+
+document.addEventListener('DOMContentLoaded', function () {
+    const boardIdInput = document.getElementById('boardId');
+
+    // 게시판 목록 가져오기
+    fetch('/api/boards')
+        .then(handleResponse)
+        .then(data => {
+            const boardList = document.getElementById('board-list');
+            data.forEach(board => {
+                const li = document.createElement('li');
+                const a = document.createElement('a');
+                a.href = `#`;
+                a.textContent = board.name;
+                a.addEventListener('click', function (event) {
+                    event.preventDefault();
+                    boardIdInput.value = board.boardId; // 현재 게시판 업데이트
+                    updateBoardContent(board.boardId);
+                });
+                li.appendChild(a);
+                boardList.appendChild(li);
+            });
+        })
+        .catch(error => handleError(error, '게시판 목록을 가져오는 중에 문제가 발생했습니다.'));
+
+    // 초기 로딩 시 데이터 가져오기
+    updateBoardContent(boardIdInput.value);
+
+    // 검색 기능
+    document.getElementById('search-form').addEventListener('submit', function (event) {
+        event.preventDefault();
+        const formData = new FormData(this); // 현재 form의 데이터를 가져옴 (검색 옵션, 내용)
+        const boardId = boardIdInput.value;
+        const searchCategory = formData.get('searchCategory');
+        const searchKeyword = formData.get('searchKeyword');
+        let searchParams = `boardId=${boardId}&page=1`;
+
+        if (searchCategory === 'title') {
+            searchParams += `&title=${searchKeyword}`;
+        } else if (searchCategory === 'content') {
+            searchParams += `&content=${searchKeyword}`;
+        } else if (searchCategory === 'title-content') {
+            searchParams += `&title=${searchKeyword}&content=${searchKeyword}`;
+        } else if (searchCategory === 'nickname') {
+            searchParams += `&nickname=${searchKeyword}`;
+        }
+
+        fetch(`/api/posts/search?${searchParams}`)
+            .then(handleResponse)
+            .then(data => {
+                if (!data || data.length === 0) {
+                    displayNoPostsMessage('검색 결과가 없습니다.');
+                } else {
+                    displayPosts(data);
+                }
+            })
+            .catch(error => handleError(error, '게시물을 검색하는 중에 문제가 발생했습니다.'));
+    });
+});
+
+function updateBoardContent(boardId) {
+    fetchPopularPosts(boardId);
+    fetchRecentPosts(boardId); // 초기 게시물 가져오기
+    updatePagination(boardId);
+    fetchNotices();
+}
+
+function fetchNotices() {
+    fetch('/api/boards/notices')
+        .then(handleResponse)
+        .then(data => {
+            const noticeList = document.getElementById('notice-list');
+            noticeList.innerHTML = '';
+            data.forEach(notice => {
+                const li = document.createElement('li');
+                li.innerHTML = `
+                    <h4>${notice.title}</h4>
+                    <p>${notice.content}</p>
+                    <span>작성일: ${notice.createdAt}</span>`;
+                noticeList.appendChild(li);
+            });
+        })
+        .catch(error => handleError(error, '공지사항을 가져오는 중에 문제가 발생했습니다.'));
+}
+
+function fetchPopularPosts(boardId) {
+    fetch(`/api/posts/hot/${boardId}`)
+        .then(response => {
+            if (response.status === 204) {
+                displayNoPopularPostsMessage('주간 인기글이 없습니다.');
+                return null;
+            }
+            return handleResponse(response);
+        })
+        .then(data => {
+            if (data) {
+                const popularPosts = document.getElementById('popular-posts');
+                popularPosts.innerHTML = `
+                    <h4>${data.title}</h4>
+                    <p>${data.content}</p>
+                    <img src="https://placehold.co/30x30" alt="Placeholder Image">
+                    <p>작성일: ${data.createdAt}</p>
+                    <p>조회수: ${data.viewCount}</p>
+                    <p>좋아요: ${data.likes}</p>
+                    <p>댓글 수: ${data.commentsCount}</p>
+                    <p>작성자: ${data.nickname}</p>`;
+            }
+        })
+        .catch(error => handleError(error, '인기 게시물을 가져오는 중에 문제가 발생했습니다.'));
+}
+
+function fetchRecentPosts(boardId, page = 1) {
+    fetch(`/api/boards/posts?boardId=${boardId}&page=${page}`)
+        .then(response => {
+            if (response.status === 204) {
+                displayNoPostsMessage('게시판이 비어 있습니다.');
+                return null;
+            }
+            return handleResponse(response);
+        })
+        .then(data => {
+            if (data) {
+                displayPosts(data);
+            }
+        })
+        .catch(error => handleError(error, '게시물 목록을 가져오는 중에 문제가 발생했습니다.'));
+}
+
+function updatePagination(boardId) {
+    fetch(`/api/boards/${boardId}/pagescount`)
+        .then(handleResponse)
+        .then(count => {
+            pageCount = count; // 총 페이지 수 업데이트
+            displayPagination(); // 페이지네이션 표시
+        })
+        .catch(error => handleError(error, '페이지 수를 가져오는 중에 문제가 발생했습니다.'));
+}
+
+function displayPagination() {
+    const pagination = document.getElementById('pagination');
+    pagination.innerHTML = ''; // 이전 페이지네이션 내용 지우기
+
+    // 이전 버튼 추가
+    if (currentPage > 1) {
+        const prevButton = document.createElement('a');
+        prevButton.href = `#`;
+        prevButton.textContent = '이전';
+        prevButton.addEventListener('click', function (event) {
+            event.preventDefault();
+            currentPage -= pagesToShow; // 이전 세트로 이동
+            if (currentPage < 1) {
+                currentPage = 1; // 1 페이지 이상으로 내려가지 않도록 보장
+            }
+            fetchRecentPosts(document.getElementById('boardId').value, currentPage);
+            displayPagination(); // 페이지네이션 표시 갱신
+        });
+        pagination.appendChild(prevButton); // 이전 버튼을 페이지네이션에 추가
+    }
+
+    const startPage = Math.floor((currentPage - 1) / pagesToShow) * pagesToShow + 1;
+    const endPage = Math.min(startPage + pagesToShow - 1, pageCount);
+
+    // 페이지 번호 표시
+    for (let i = startPage; i <= endPage; i++) {
+        const a = document.createElement('a');
+        a.href = `#`;
+        a.textContent = i;
+        a.className = i === currentPage ? 'active' : ''; // 현재 페이지 강조
+        a.addEventListener('click', function (event) {
+            event.preventDefault();
+            currentPage = i; // 현재 페이지 업데이트
+            fetchRecentPosts(document.getElementById('boardId').value, currentPage);
+            displayPagination(); // 페이지네이션 표시 갱신
+        });
+        pagination.appendChild(a);
+    }
+
+    // 다음 버튼 표시
+    if (endPage < pageCount) {
+        const nextButton = document.createElement('a');
+        nextButton.href = `#`;
+        nextButton.textContent = '다음';
+        nextButton.addEventListener('click', function (event) {
+            event.preventDefault();
+            currentPage += pagesToShow; // 다음 세트로 이동
+            if (currentPage > pageCount) {
+                currentPage = pageCount; // 총 페이지를 초과하지 않도록 보장
+            }
+            fetchRecentPosts(document.getElementById('boardId').value, currentPage);
+            displayPagination(); // 페이지네이션 표시 갱신
+        });
+        pagination.appendChild(nextButton); // 다음 버튼을 페이지네이션에 추가
+    }
+}
+
+function displayPosts(posts) {
+    const postList = document.getElementById('post-list');
+    postList.innerHTML = ''; // 이전 게시물 지우기
+
+    posts.forEach(post => {
+        const li = document.createElement('li');
+        li.innerHTML = `
+            <h4>${post.title}</h4>
+            <p>${post.content}</p>
+            <img src="https://placehold.co/30x30" alt="Placeholder Image">
+            <p>작성일: ${post.createdAt}</p>
+            <p>조회수: ${post.viewCount}</p>
+            <p>좋아요: ${post.likes}</p>
+            <p>댓글 수: ${post.commentsCount}</p>
+            <p>작성자: ${post.nickname}</p>`;
+        postList.appendChild(li);
+    });
+}
+
+function handleResponse(response) {
+    if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    return response.json();
+}
+
+function handleError(error, contextMessage) {
+    console.error('Error:', error);
+    displayNoPostsMessage(`${contextMessage} - ${error.message}`);
+}
+
+function displayNoPostsMessage(message) {
+    const postList = document.getElementById('post-list');
+    postList.innerHTML = `<p>${message}</p>`;
+}
+
+function displayNoPopularPostsMessage(message) {
+    const popularPosts = document.getElementById('popular-posts');
+    popularPosts.innerHTML = `<p>${message}</p>`;
+}

--- a/src/main/resources/templates/example2.html
+++ b/src/main/resources/templates/example2.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>게시글 목록 페이지</title>
+    <link rel="stylesheet" href="/css/board-list.css">
+</head>
+<body>
+<!-- 헤더 영역 -->
+<header>
+    <div>로고</div>
+    <div>메뉴 아이템들</div>
+    <div>로그아웃, 마이페이지</div>
+</header>
+
+<!-- 사이드바 -->
+<div class="sidebar">
+    <h3>게시판 목록</h3>
+    <ul id="board-list"></ul>
+</div>
+
+<!-- 메인 콘텐츠 -->
+<div class="main-content">
+    <!-- 주간 인기글 -->
+    <div class="popular-post">
+        <h3>주간 인기글</h3>
+        <div id="popular-posts"></div>
+    </div>
+
+    <div class="recent-post">
+        <h3>최근 게시글</h3>
+
+        <!-- 검색 영역 -->
+        <div class="search-bar">
+            <form id="search-form">
+                <input type="hidden" name="boardId" th:value="${boardId}" id="boardId"/>
+                <select name="searchCategory" id="searchCategory">
+                    <option value="title">제목</option>
+                    <option value="content">내용</option>
+                    <option value="title-content">제목 + 내용</option>
+                    <option value="nickname">글쓴이</option>
+                </select>
+                <input type="text" name="searchKeyword" placeholder="검색어 입력" required>
+                <button type="submit" class="button">검색</button>
+            </form>
+        </div>
+
+        <!-- 공지사항 목록 -->
+        <div class="notice-section">
+            <h4>공지사항</h4>
+            <ul id="notice-list"></ul>
+        </div>
+
+        <!-- 일반 게시글 목록 -->
+        <div id="recent-posts">
+            <h4>일반 게시글</h4>
+            <ul id="post-list"></ul>
+        </div>
+    </div>
+</div>
+
+<div class="pagination" id="pagination"></div>
+
+<script src="/js/board-list.js"></script>
+</body>
+</html>


### PR DESCRIPTION
### PostSearchResultDto
- 검색 시 해당 게시글과 총 페이지 갯수를 저장하는 DTO 추가

### NoticeResponseDto
- 공지사항 게시글의 내용을 저장하는 DTO 추가

### PostResponseDto
- userId가 아닌 nickname을 저장하도록 수정

### BoardController
- 검색 시 검색 결과에 해당하는 페이지 수도 함께 반환하도록 수정

### PostsService
- 공지사항과 일반 게시글을 반환하는 메소드 분리
-  검색 시 검색 결과에 해당하는 페이지 수가 반환되는 메소드 추가

### PostsController
-  검색 시 반환되는 타입을 PostSearchResultDto로 변경

### PostsRepository
- 검색한 게시글의 갯수에 따른 총 페이지 갯수를 반환하도록 추가

### UserRepository
- userId를 통해 nickname을 반환하도록 추가

### example2.html, board-list.js, board-list.css
- 동적으로 동작하는 뷰 추가