### PR TITLE
관리자 View 페이지 추가 및 굿즈 관련 메서드 추가

### DIFF
--- a/src/main/java/com/walking/project_walking/controller/AdminViewController.java
+++ b/src/main/java/com/walking/project_walking/controller/AdminViewController.java
@@ -1,8 +1,10 @@
 package com.walking.project_walking.controller;
 
+import com.walking.project_walking.domain.Goods;
 import com.walking.project_walking.domain.Users;
 import com.walking.project_walking.domain.dto.BoardResponseDto;
 import com.walking.project_walking.service.BoardService;
+import com.walking.project_walking.service.GoodsService;
 import com.walking.project_walking.service.UserService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class AdminViewController {
     private final UserService userService;
     private final BoardService boardService;
+    private final GoodsService goodsService;
 
     @GetMapping
     public String adminView(Model model) {
@@ -44,5 +47,12 @@ public class AdminViewController {
         List<BoardResponseDto> boardList = boardService.getBoardsList();
         model.addAttribute("boardList", boardList);
         return "board";
+    }
+
+    @GetMapping("/goods")
+    public String manageGoods(Model model) {
+        List<Goods> goodsList = goodsService.getAllGoods();
+        model.addAttribute("goodsList", goodsList);
+        return "goods-manager";
     }
 }

--- a/src/main/java/com/walking/project_walking/controller/GoodsController.java
+++ b/src/main/java/com/walking/project_walking/controller/GoodsController.java
@@ -26,20 +26,26 @@ public class GoodsController {
         return goodsService.getAllGoods();
     }
 
+    @GetMapping("/{goodsId}")
+    public ResponseEntity<Goods> getGoods(@PathVariable Long goodsId) {
+        Goods goods = goodsService.getGoodsById(goodsId);
+        return ResponseEntity.ok(goods);
+    }
+
     // Admin Only
     @PostMapping
-    public ResponseEntity<String> addGoods(@RequestBody Goods goods) {
+    public ResponseEntity<Goods> addGoods(@RequestBody Goods goods) {
         goodsService.addGoods(goods);
-        return ResponseEntity.status(HttpStatus.CREATED).body("굿즈가 추가되었습니다.\nID: " + goods.getGoodsId());
+        return ResponseEntity.status(HttpStatus.CREATED).body(goods);
     }
 
     // Admin Only
     @PutMapping("/{goodsId}")
-    public ResponseEntity<String> updateGoods(@RequestBody Goods goods, @PathVariable Long goodsId) {
+    public ResponseEntity<Goods> updateGoods(@RequestBody Goods goods, @PathVariable Long goodsId) {
         Goods newGoods = goodsService.updateGoods(goodsId, goods);
         if (newGoods != null)
-            return ResponseEntity.status(HttpStatus.OK).body(goods.toString());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(goodsId + " 에 해당하는 굿즈가 없습니다.");
+            return ResponseEntity.status(HttpStatus.OK).body(newGoods);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
     }
 
     // Admin Only
@@ -52,7 +58,7 @@ public class GoodsController {
     }
 
     @PostMapping("/{goodsId}/{userId}/purchase")
-    public ResponseEntity<String> purchaseGoods(@RequestBody Goods goods, @PathVariable Long goodsId, @PathVariable Long userId) {
+    public ResponseEntity<String> purchaseGoods(@PathVariable Long goodsId, @PathVariable Long userId) {
         Boolean isSuccessful = goodsService.purchaseGoods(goodsId, userId);
         if (isSuccessful == Boolean.FALSE)
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("포인트가 충분하지 않거나, 올바르지 않은 굿즈입니다.");

--- a/src/main/java/com/walking/project_walking/controller/GoodsViewController.java
+++ b/src/main/java/com/walking/project_walking/controller/GoodsViewController.java
@@ -1,0 +1,29 @@
+package com.walking.project_walking.controller;
+
+import com.walking.project_walking.domain.Goods;
+import com.walking.project_walking.domain.Users;
+import com.walking.project_walking.service.GoodsService;
+import com.walking.project_walking.service.UserService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/goods")
+@RequiredArgsConstructor
+public class GoodsViewController {
+    private final GoodsService goodsService;
+    private final UserService userService;
+
+    @GetMapping
+    public String goods(Model model) {
+        List<Goods> goodsList = goodsService.getAllGoods();
+        Users user = userService.findById(2L);
+        model.addAttribute("user", user);
+        model.addAttribute("goodsList", goodsList);
+        return "goods";
+    }
+}

--- a/src/main/java/com/walking/project_walking/domain/Goods.java
+++ b/src/main/java/com/walking/project_walking/domain/Goods.java
@@ -14,7 +14,6 @@ import lombok.Setter;
 @Table(name = "goods")
 public class Goods {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "goods_id", nullable = false)
     private Long goodsId;
 

--- a/src/main/java/com/walking/project_walking/service/GoodsService.java
+++ b/src/main/java/com/walking/project_walking/service/GoodsService.java
@@ -55,7 +55,7 @@ public class GoodsService {
     }
 
     @Transactional
-    public Boolean purchaseGoods(Long userId, Long goodsId) {
+    public Boolean purchaseGoods(Long goodsId, Long userId) {
         Users user = userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("올바르지 않은 유저 ID 입니다."));
         if (user == null)                       // 유저가 null 일때
             return Boolean.FALSE;

--- a/src/main/resources/static/css/normalize.css
+++ b/src/main/resources/static/css/normalize.css
@@ -1,0 +1,349 @@
+/*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
+
+/* Document
+   ========================================================================== */
+
+/**
+ * 1. Correct the line height in all browsers.
+ * 2. Prevent adjustments of font size after orientation changes in iOS.
+ */
+
+html {
+    line-height: 1.15; /* 1 */
+    -webkit-text-size-adjust: 100%; /* 2 */
+}
+
+/* Sections
+   ========================================================================== */
+
+/**
+ * Remove the margin in all browsers.
+ */
+
+body {
+    margin: 0;
+}
+
+/**
+ * Render the `main` element consistently in IE.
+ */
+
+main {
+    display: block;
+}
+
+/**
+ * Correct the font size and margin on `h1` elements within `section` and
+ * `article` contexts in Chrome, Firefox, and Safari.
+ */
+
+h1 {
+    font-size: 2em;
+    margin: 0.67em 0;
+}
+
+/* Grouping content
+   ========================================================================== */
+
+/**
+ * 1. Add the correct box sizing in Firefox.
+ * 2. Show the overflow in Edge and IE.
+ */
+
+hr {
+    box-sizing: content-box; /* 1 */
+    height: 0; /* 1 */
+    overflow: visible; /* 2 */
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+pre {
+    font-family: monospace, monospace; /* 1 */
+    font-size: 1em; /* 2 */
+}
+
+/* Text-level semantics
+   ========================================================================== */
+
+/**
+ * Remove the gray background on active links in IE 10.
+ */
+
+a {
+    background-color: transparent;
+}
+
+/**
+ * 1. Remove the bottom border in Chrome 57-
+ * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
+ */
+
+abbr[title] {
+    border-bottom: none; /* 1 */
+    text-decoration: underline; /* 2 */
+    text-decoration: underline dotted; /* 2 */
+}
+
+/**
+ * Add the correct font weight in Chrome, Edge, and Safari.
+ */
+
+b,
+strong {
+    font-weight: bolder;
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+code,
+kbd,
+samp {
+    font-family: monospace, monospace; /* 1 */
+    font-size: 1em; /* 2 */
+}
+
+/**
+ * Add the correct font size in all browsers.
+ */
+
+small {
+    font-size: 80%;
+}
+
+/**
+ * Prevent `sub` and `sup` elements from affecting the line height in
+ * all browsers.
+ */
+
+sub,
+sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+}
+
+sub {
+    bottom: -0.25em;
+}
+
+sup {
+    top: -0.5em;
+}
+
+/* Embedded content
+   ========================================================================== */
+
+/**
+ * Remove the border on images inside links in IE 10.
+ */
+
+img {
+    border-style: none;
+}
+
+/* Forms
+   ========================================================================== */
+
+/**
+ * 1. Change the font styles in all browsers.
+ * 2. Remove the margin in Firefox and Safari.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+    font-family: inherit; /* 1 */
+    font-size: 100%; /* 1 */
+    line-height: 1.15; /* 1 */
+    margin: 0; /* 2 */
+}
+
+/**
+ * Show the overflow in IE.
+ * 1. Show the overflow in Edge.
+ */
+
+button,
+input { /* 1 */
+    overflow: visible;
+}
+
+/**
+ * Remove the inheritance of text transform in Edge, Firefox, and IE.
+ * 1. Remove the inheritance of text transform in Firefox.
+ */
+
+button,
+select { /* 1 */
+    text-transform: none;
+}
+
+/**
+ * Correct the inability to style clickable types in iOS and Safari.
+ */
+
+button,
+[type="button"],
+[type="reset"],
+[type="submit"] {
+    -webkit-appearance: button;
+}
+
+/**
+ * Remove the inner border and padding in Firefox.
+ */
+
+button::-moz-focus-inner,
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner {
+    border-style: none;
+    padding: 0;
+}
+
+/**
+ * Restore the focus styles unset by the previous rule.
+ */
+
+button:-moz-focusring,
+[type="button"]:-moz-focusring,
+[type="reset"]:-moz-focusring,
+[type="submit"]:-moz-focusring {
+    outline: 1px dotted ButtonText;
+}
+
+/**
+ * Correct the padding in Firefox.
+ */
+
+fieldset {
+    padding: 0.35em 0.75em 0.625em;
+}
+
+/**
+ * 1. Correct the text wrapping in Edge and IE.
+ * 2. Correct the color inheritance from `fieldset` elements in IE.
+ * 3. Remove the padding so developers are not caught out when they zero out
+ *    `fieldset` elements in all browsers.
+ */
+
+legend {
+    box-sizing: border-box; /* 1 */
+    color: inherit; /* 2 */
+    display: table; /* 1 */
+    max-width: 100%; /* 1 */
+    padding: 0; /* 3 */
+    white-space: normal; /* 1 */
+}
+
+/**
+ * Add the correct vertical alignment in Chrome, Firefox, and Opera.
+ */
+
+progress {
+    vertical-align: baseline;
+}
+
+/**
+ * Remove the default vertical scrollbar in IE 10+.
+ */
+
+textarea {
+    overflow: auto;
+}
+
+/**
+ * 1. Add the correct box sizing in IE 10.
+ * 2. Remove the padding in IE 10.
+ */
+
+[type="checkbox"],
+[type="radio"] {
+    box-sizing: border-box; /* 1 */
+    padding: 0; /* 2 */
+}
+
+/**
+ * Correct the cursor style of increment and decrement buttons in Chrome.
+ */
+
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
+    height: auto;
+}
+
+/**
+ * 1. Correct the odd appearance in Chrome and Safari.
+ * 2. Correct the outline style in Safari.
+ */
+
+[type="search"] {
+    -webkit-appearance: textfield; /* 1 */
+    outline-offset: -2px; /* 2 */
+}
+
+/**
+ * Remove the inner padding in Chrome and Safari on macOS.
+ */
+
+[type="search"]::-webkit-search-decoration {
+    -webkit-appearance: none;
+}
+
+/**
+ * 1. Correct the inability to style clickable types in iOS and Safari.
+ * 2. Change font properties to `inherit` in Safari.
+ */
+
+::-webkit-file-upload-button {
+    -webkit-appearance: button; /* 1 */
+    font: inherit; /* 2 */
+}
+
+/* Interactive
+   ========================================================================== */
+
+/*
+ * Add the correct display in Edge, IE 10+, and Firefox.
+ */
+
+details {
+    display: block;
+}
+
+/*
+ * Add the correct display in all browsers.
+ */
+
+summary {
+    display: list-item;
+}
+
+/* Misc
+   ========================================================================== */
+
+/**
+ * Add the correct display in IE 10+.
+ */
+
+template {
+    display: none;
+}
+
+/**
+ * Add the correct display in IE 10.
+ */
+
+[hidden] {
+    display: none;
+}

--- a/src/main/resources/static/js/admin-page.js
+++ b/src/main/resources/static/js/admin-page.js
@@ -9,6 +9,7 @@ $(window).on('load', function() {
 
   const manage_user = document.getElementById('manage-user');
   const manage_board = document.getElementById('manage-board');
+  const manage_goods = document.getElementById('manage-goods');
 
   manage_user.addEventListener('click', function() {
     $.ajax({
@@ -35,4 +36,17 @@ $(window).on('load', function() {
       }
     });
   });
+
+  manage_goods.addEventListener('click', function() {
+    $.ajax({
+      url: '/admin/goods',
+      method: 'GET',
+      success: function(data) {
+        $('#data').html(data);
+      },
+      error: function(xhr, status, error) {
+        $('#data').html('Error: ' + error);
+      }
+    });
+  })
 });

--- a/src/main/resources/templates/admin.html
+++ b/src/main/resources/templates/admin.html
@@ -3,13 +3,13 @@
 <head>
   <meta charset="UTF-8">
   <title>Title</title>
+  <link rel="stylesheet" th:href="@{css/normalize.css}">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-  <link th:href="@{/css/bootstrap-addon.css}" rel="stylesheet" />
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
   <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 </head>
-<body>
-<div>
+<body class="bg-dark">
+<div class="container">
   <div class="d-flex">
     <aside th:replace="~{/fragments/sidebar.html :: fragment-admin-sidebar(user=${user})}">TestAside</aside>
     <span id="data" style="width: 100%">Loading...</span>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -1,49 +1,51 @@
-<div th:fragment="fragment-header">
-  <nav class="navbar sticky-top navbar-expand-lg bg-body-tertiary">
-    <div class="container-fluid">
-      <a class="navbar-brand" href="#">Project Icon</a>
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse" id="navbarNavDropdown">
-        <ul class="navbar-nav">
-          <li class="nav-item">
-            <a class="nav-link active" aria-current="page" href="#">홈</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="#">포인트 상점</a>
-          </li>
-          <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-              게시판
-            </a>
-            <ul class="dropdown-menu">
-              <li><a class="dropdown-item" href="#">걷기 인증 게시판</a></li>
-              <li><a class="dropdown-item" href="#">자유 게시판</a></li>
-            </ul>
-          </li>
-          <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-              문의하기
-            </a>
-            <ul class="dropdown-menu">
-              <li><a class="dropdown-item" href="#">1대1 문의</a></li>
-              <li><a class="dropdown-item" href="#">자주 묻는 질문</a></li>
-            </ul>
-          </li>
-          <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-              Test님 반갑습니다!
-            </a>
-            <ul class="dropdown-menu">
-              <li><a class="dropdown-item disabled" href="#">내 포인트: 5000</a></li>
-              <li><hr class="dropdown-divider"></li>
-              <li><a class="dropdown-item" href="#">마이 페이지</a></li>
-              <li><a class="dropdown-item" href="#">로그아웃</a></li>
-            </ul>
-          </li>
-        </ul>
-      </div>
+<nav class="navbar sticky-top navbar-expand-lg bg-body-tertiary container" th:fragment="fragment-header">
+  <div class="container-fluid d-flex justify-content-between">
+    <a class="navbar-brand" href="#">Project Icon</a>
+
+    <div class="mx-auto d-flex justify-content-center">
+      <ul class="navbar-nav">
+        <li class="nav-item mx-3">
+          <a class="nav-link active" aria-current="page" th:href="@{/}">홈</a>
+        </li>
+        <li class="nav-item mx-3">
+          <a class="nav-link" th:href="@{/goods}">포인트 상점</a>
+        </li>
+        <li class="nav-item dropdown mx-3">
+          <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+            게시판
+          </a>
+          <ul class="dropdown-menu">
+            <li><a class="dropdown-item" href="#">걷기 인증 게시판</a></li>
+            <li><a class="dropdown-item" href="#">자유 게시판</a></li>
+          </ul>
+        </li>
+        <li class="nav-item dropdown mx-3">
+          <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+            문의하기
+          </a>
+          <ul class="dropdown-menu">
+            <li><a class="dropdown-item" href="#">1대1 문의</a></li>
+            <li><a class="dropdown-item" href="#">자주 묻는 질문</a></li>
+          </ul>
+        </li>
+      </ul>
     </div>
-  </nav>
-</div>
+
+    <div class="d-flex align-items-center">
+      <ul class="navbar-nav">
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+            [[${user.getNickname()}]]님 반갑습니다!
+          </a>
+          <ul class="dropdown-menu">
+            <li><a class="dropdown-item disabled" href="#">내 포인트: [[${#numbers.formatInteger(user.point, 0, 'COMMA')}]]P</a></li>
+            <li><hr class="dropdown-divider"></li>
+            <li><a class="dropdown-item" href="#">마이 페이지</a></li>
+            <li><a class="dropdown-item" th:href="@{/auth/logout}">로그아웃</a></li>
+          </ul>
+        </li>
+      </ul>
+    </div>
+  </div>
+  <link th:href="@{/css/bootstrap-addon.css}" rel="stylesheet" />
+</nav>

--- a/src/main/resources/templates/fragments/sidebar.html
+++ b/src/main/resources/templates/fragments/sidebar.html
@@ -15,6 +15,11 @@
         게시판 관리
       </a>
     </li>
+    <li>
+      <a href="#" class="nav-link text-white" id="manage-goods">
+        굿즈 관리
+      </a>
+    </li>
   </ul>
   <hr>
   <div class="d-flex column-gap-5 justify-content-between">
@@ -22,7 +27,7 @@
       <img src="https://placehold.co/32x32" alt="" width="32" height="32" class="rounded-circle me-2">
       <strong th:text="${user.getNickname()}"></strong>
     </a>
-    <a href="#" class="d-flex align-items-center text-white text-decoration-none" >
+    <a th:href="@{/auth/logout}" class="d-flex align-items-center text-white text-decoration-none" >
       로그아웃
     </a>
   </div>

--- a/src/main/resources/templates/goods-manager.html
+++ b/src/main/resources/templates/goods-manager.html
@@ -1,0 +1,246 @@
+<div style="width: 100%;">
+  <table class="table table-dark table-striped" id="goodsTable">
+    <thead>
+    <tr>
+      <th scope="col">#</th>
+      <th scope="col" class="text-center">이름</th>
+      <th scope="col" class="text-center">설명</th>
+      <th scope="col" class="text-center">가격</th>
+      <th scope="col"></th>
+      <th scope="col"><a href="javascript:void(0);" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#addGoodsModal">추가하기</a></th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr th:each="goods : ${goodsList}" th:id="'GoodsRow' + ${goods.getGoodsId()}">
+      <td th:text="${goods.getGoodsId()}"></td>
+      <td th:text="${goods.getName()}"></td>
+      <td th:text="${goods.getDescription()}"></td>
+      <td th:text="${#numbers.formatInteger(goods.getPrice(), 0, 'COMMA')}"></td>
+      <td><a href="#" class="btn btn-success" th:onclick="'editGoods(' + ${goods.goodsId} + ')'">수정</a></td>
+      <td><a href="#" class="btn btn-danger" th:onclick="'deleteGoods(' + ${goods.goodsId} + ')'">삭제</a></td>
+    </tr>
+    </tbody>
+  </table>
+</div>
+
+<div class="modal fade" id="addGoodsModal" tabindex="-1" aria-labelledby="addGoodsModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="addGoodsModalLabel">아이템 추가</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <form id="addGoodsForm">
+          <div class="mb-3">
+            <label for="GoodsType" class="form-label">아이템 종류</label>
+            <select class="form-select" id="GoodsType" required>
+              <option value="1">소모성</option>
+              <option value="2">치장</option>
+            </select>
+          </div>
+          <div class="mb-3">
+            <label for="GoodsCode" class="form-label">아이템 코드</label>
+            <input type="text" class="form-control" id="GoodsCode" required>
+          </div>
+          <div class="mb-3">
+            <label for="GoodsName" class="form-label">아이템 이름</label>
+            <input type="text" class="form-control" id="GoodsName" required>
+          </div>
+          <div class="mb-3">
+            <label for="GoodsDescription" class="form-label">아이템 설명</label>
+            <input type="text" class="form-control" id="GoodsDescription" required>
+          </div>
+          <div class="mb-3">
+            <label for="GoodsPrice" class="form-label">가격</label>
+            <input type="number" class="form-control" id="GoodsPrice" required>
+          </div>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
+        <button type="button" class="btn btn-primary" id="submitGoods">추가하기</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="failureModal" tabindex="-1" aria-labelledby="failureModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="failureModalLabel">오류 발생</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p id="failureMessage">처리 중 오류가 발생했습니다. 다시 시도해 주세요.</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">닫기</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="deleteGoodsModal" tabindex="-1" aria-labelledby="deleteGoodsModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="deleteGoodsModalLabel">삭제 확인</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p>정말로 이 아이템을 삭제하시겠습니까?</p>
+        <p>삭제 후에는 복구할 수 없습니다.</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
+        <button type="button" class="btn btn-danger" id="confirmDeleteBtn">삭제하기</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="editGoodsModal" tabindex="-1" aria-labelledby="editGoodsModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="editGoodsModalLabel">아이템 수정</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <form id="editGoodsForm">
+          <input type="hidden" id="editGoodsId">
+
+          <div class="mb-3">
+            <label for="editGoodsName" class="form-label">아이템 이름</label>
+            <input type="text" class="form-control" id="editGoodsName" required>
+          </div>
+
+          <div class="mb-3">
+            <label for="editGoodsDescription" class="form-label">아이템 설명</label>
+            <input type="text" class="form-control" id="editGoodsDescription" required>
+          </div>
+
+          <div class="mb-3">
+            <label for="editGoodsPrice" class="form-label">가격</label>
+            <input type="number" class="form-control" id="editGoodsPrice" required>
+          </div>
+
+          <button type="button" class="btn btn-primary" id="saveEditBtn">수정하기</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  function editGoods(goodsId) {
+    $.ajax({
+      url: `/api/goods/${goodsId}`,
+      type: 'GET',
+      success: function(response) {
+        $('#editGoodsName').val(response.name);
+        $('#editGoodsDescription').val(response.description);
+        $('#editGoodsPrice').val(response.price);
+
+        $('#saveEditBtn').off('click').on('click', function() {
+          var updatedData = {
+            name: $('#editGoodsName').val(),
+            description: $('#editGoodsDescription').val(),
+            price: $('#editGoodsPrice').val()
+          };
+
+          $.ajax({
+            url: `/api/goods/${goodsId}`,
+            type: 'PUT',
+            contentType: 'application/json',
+            data: JSON.stringify(updatedData),
+            success: function(response) {
+              $(`#GoodsRow${goodsId} td:nth-child(2)`).text(response.name);
+              $(`#GoodsRow${goodsId} td:nth-child(3)`).text(response.description);
+              $(`#GoodsRow${goodsId} td:nth-child(4)`).text(Intl.NumberFormat().format(response.price));
+
+              $('#editGoodsModal').modal('hide');
+            },
+            error: function(xhr, status, error) {
+              $('#failureMessage').text(`아이템 수정 실패: ${error}`);
+              $('#failureModal').modal('show');
+            }
+          });
+        });
+
+        $('#editGoodsModal').modal('show');
+      }
+    });
+  }
+
+  function deleteGoods(goodsId) {
+    $('#deleteGoodsModal').modal('show');
+
+    $('#confirmDeleteBtn').off('click').on('click', function() {
+      $.ajax({
+        url: `/api/goods/${goodsId}`,
+        type: 'DELETE',
+        success: function(response) {
+          $(`#GoodsRow${goodsId}`).remove();
+          $('#deleteGoodsModal').modal('hide');
+        },
+        error: function(xhr, status, error) {
+          $('#failureMessage').text(`아이템 삭제 실패: ${error}`);
+          $('#failureModal').modal('show');
+          $('#deleteGoodsModal').modal('hide');
+        }
+      });
+    });
+  }
+
+  $(document).ready(function() {
+    $('#submitGoods').click(function() {
+      const GoodsType = $('#GoodsType').val();
+      const GoodsCode = $('#GoodsCode').val();
+      const GoodsName = $('#GoodsName').val();
+      const GoodsDescription = $('#GoodsDescription').val();
+      const GoodsPrice = $('#GoodsPrice').val();
+
+      if (!GoodsCode || !GoodsName || !GoodsDescription || !GoodsPrice) {
+        alert('모든 필드를 채워주세요.');
+        return;
+      }
+
+      const newGoods = {
+        goodsId: Number(GoodsType * 100000) + Number(GoodsCode),
+        name: GoodsName,
+        description: GoodsDescription,
+        price: GoodsPrice
+      };
+
+      $.ajax({
+        url: '/api/goods',
+        type: 'POST',
+        contentType: 'application/json',
+        data: JSON.stringify(newGoods),
+        success: function(response) {
+          const newRow = `
+            <tr id="GoodsRow${response.goodsId}">
+              <td>${response.goodsId}</td>
+              <td>${response.name}</td>
+              <td>${response.description}</td>
+              <td>${Intl.NumberFormat().format(response.price)}</td>
+              <td><a href="#" class="btn btn-success" onclick="editGoods(${response.goodsId})">수정</a></td>
+              <td><a href="#" class="btn btn-danger" onclick="deleteGoods(${response.goodsId})">삭제</a></td>
+            </tr>
+          `;
+          $('#goodsTable tbody').append(newRow);
+
+          $('#addGoodsModal').modal('hide');
+          $('#addGoodsForm')[0].reset();
+        },
+        error: function(xhr, status, error) {
+          $('#failureMessage').text(`아이템 추가 실패: ${error}`);
+          $('#failureModal').modal('show');
+        }
+      });
+    });
+  });
+</script>

--- a/src/main/resources/templates/goods.html
+++ b/src/main/resources/templates/goods.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+</head>
+<body>
+<nav th:replace="~{/fragments/header.html :: fragment-header(user=${user})}"></nav>
+<div class="container px-4">
+  <div class="row d-flex justify-content-start g-4">
+    <div th:each="goods : ${goodsList}" class="col-12 col-sm-6 col-md-4 col-lg-3">
+      <div class="card" style="width: 100%; height: 100%;">
+        <img src="https://placehold.co/286x180" class="card-img-top" alt="아이템 이미지">
+        <div class="card-body d-flex flex-column justify-content-between">
+          <h5 class="card-title" th:text="${goods.getName()}">아이템 이름</h5>
+          <span th:if="${goods.getGoodsId() / 100000 == 1}" class="badge bg-success ms-2">소모성</span>
+          <span th:if="${goods.getGoodsId() / 100000 == 2}" class="badge bg-info ms-2">치장</span>
+          <p class="card-text description-text" th:text="${goods.getDescription()}">아이템 설명</p>
+          <div class="d-flex justify-content-between align-items-center mt-auto">
+            <a href="javascript:void(0);" class="btn btn-primary purchase-btn"
+               th:data-goods-id="${goods.getGoodsId()}" th:data-goods-price="${goods.getPrice()}"
+               th:data-user-id="${user.getUserId()}" th:data-user-point="${user.getPoint()}"
+               th:data-goods-name="${goods.getName()}"
+               th:text="${#numbers.formatInteger(goods.price, 0, 'COMMA')} + 'P'">
+              구매하기
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="purchaseModal" tabindex="-1" aria-labelledby="purchaseModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="purchaseModalLabel">구매 확인</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p>구매할 아이템 이름: <span id="selectedGoods">null</span></p>
+        <p>현재 보유 포인트: <span id="currentPoints">0</span>P</p>
+        <p>구매 후 남은 포인트: <span id="remainingPoints">0</span>P</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
+        <button type="button" id="confirmPurchase" class="btn btn-primary" disabled>구매하기</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="successModal" tabindex="-1" aria-labelledby="successModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="successModalLabel">구매 성공</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p id="successMessage"></p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">닫기</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="errorModal" tabindex="-1" aria-labelledby="errorModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="errorModalLabel">구매 실패</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p id="errorMessage"></p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">닫기</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  $(document).ready(function() {
+    $('.purchase-btn').click(function() {
+      let goodsId = $(this).data('goods-id');
+      let goodsPrice = $(this).data('goods-price');
+      let goodsName = $(this).data('goods-name');
+      const userId = $(this).data('user-id');
+
+      let currentPoints = $(this).data('userPoint');
+
+      $('#selectedGoods').text(goodsName);
+      $('#currentPoints').text(currentPoints);
+      $('#remainingPoints').text(currentPoints - goodsPrice);
+
+      if (currentPoints < goodsPrice) {
+        $('#confirmPurchase').prop('disabled', true);
+      } else {
+        $('#confirmPurchase').prop('disabled', false);
+      }
+
+      $('#confirmPurchase').off('click').on('click', function() {
+        $.ajax({
+          url: '/api/goods/{goodsId}/{userId}/purchase'.replace("{goodsId}", goodsId).replace("{userId}", userId),
+          type: 'POST',
+          contentType: 'application/json',
+          data: JSON.stringify({ "id": goodsId }),
+          success: function(response) {
+            $('#successMessage').text(response);
+            $('#successModal').modal('show');
+            $('#purchaseModal').modal('hide');
+          },
+          error: function(xhr, status, error) {
+            $('#errorMessage').text(xhr.responseText);
+            $('#errorModal').modal('show');
+            $('#purchaseModal').modal('hide');
+          }
+        });
+      });
+
+      $('#purchaseModal').modal('show');
+    });
+  });
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/user.html
+++ b/src/main/resources/templates/user.html
@@ -18,11 +18,11 @@
       </div>
       <div class="px-3">
         <p class="small text-muted mb-0">경험치</p>
-        <p class="mb-1 h5" th:text="${user.getUserExp()}"></p>
+        <p class="mb-1 h5" th:text="${#numbers.formatInteger(user.getUserExp(), 0, 'COMMA')}"></p>
       </div>
       <div class="px-3">
         <p class="small text-muted mb-0">포인트</p>
-        <p class="mb-1 h5" th:text="${user.getPoint()}"></p>
+        <p class="mb-1 h5" th:text="${#numbers.formatInteger(user.getPoint(), 0, 'COMMA')} + 'P'"></p>
       </div>
       <div class="px-3">
         <p class="small text-muted mb-0">게시물 수</p>
@@ -47,7 +47,7 @@
         <p class="font-italic mb-1">생일: [[${user.getBirth()}]]</p>
         <p class="font-italic mb-1">가입일: [[${user.getJoinDate()}]]</p>
         <p class="font-italic mb-1">최근 로그인: [[${user.getLastLogin()}]]</p>
-        <p class="font-italic mb-1">로그인 횟수: [[${user.getLoginCount()}]]</p>
+        <p class="font-italic mb-1">로그인 횟수: [[${#numbers.formatInteger(user.getLoginCount(), 0, 'COMMA')}]]</p>
         <p class="font-italic mb-1">접속 브라우저 정보: [[${user.getLoginBrowser()}]]</p>
       </div>
     </div>

--- a/src/main/resources/templates/users.html
+++ b/src/main/resources/templates/users.html
@@ -15,7 +15,6 @@
       <th scope="col" class="text-center">계정 활성화 여부</th>
       <th scope="col"></th>
       <th scope="col"></th>
-      <th scope="col"></th>
     </tr>
     </thead>
     <tbody>
@@ -35,8 +34,9 @@
         <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#userModal"
                 th:data-user-id="${user.getUserId()}">자세히</button>
       </td>
-      <td><a class="btn btn-success">수정</a></td>
-      <td><a class="btn btn-danger">삭제</a></td>
+      <td>
+        <button class="btn btn-danger disable-user-btn" th:data-user-id="${user.getUserId()}" th:disabled="${!user.getIsActive()}">비활성화</button>
+      </td>
     </tr>
     </tbody>
   </table>
@@ -59,6 +59,25 @@
   </div>
 </div>
 
+<div class="modal fade" id="deleteUserModal" tabindex="-1" aria-labelledby="deleteUserModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="deleteUserModalLabel">사용자 비활성화 확인</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p>정말로 이 사용자를 비활성화 하시겠습니까?</p>
+        <p id="userInfo"></p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
+        <button type="button" id="confirmDeleteBtn" class="btn btn-danger">삭제</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <script>
   $('#userModal').on('show.bs.modal', function(event) {
     const button = $(event.relatedTarget);
@@ -73,6 +92,36 @@
       error: function(xhr, status, error) {
         $('#modalContent').html('<p class="text-danger">오류: ' + error + '</p>');
       }
+    });
+  });
+
+  $(document).ready(function() {
+    $('.disable-user-btn').click(function() {
+      let userId = $(this).data('user-id');
+      let userRow = $(this).closest('tr');
+      let userEmail = userRow.find('td').eq(1).text();
+
+      $('#userInfo').text('이 사용자의 이메일: ' + userEmail);
+
+      $('#confirmDeleteBtn').off('click').on('click', function() {
+        $.ajax({
+          url: '/users/' + userId,
+          type: 'DELETE',
+          success: function(response) {
+            alert('사용자가 비활성화되었습니다.');
+
+            userRow.find('td').eq(10).text('비활성화');
+            userRow.find('.disable-user-btn').prop('disabled', true).text('비활성화');
+
+            $('#deleteUserModal').modal('hide');
+          },
+          error: function(xhr, status, error) {
+            alert('사용자 비활성화 실패: ' + xhr.responseText);
+          }
+        });
+      });
+
+      $('#deleteUserModal').modal('show');
     });
   });
 </script>


### PR DESCRIPTION
#### AdminViewController.java
* 관리자 뷰 페이지에서 비동기로 굿즈 리스트를 받아오기 위한 매핑을 추가하였습니다.

#### GoodsController.java
* 단일 굿즈의 정보를 가져오기 위한 매핑을 추가하였습니다. `/{goodsId}` -> Goods

#### GoodsViewController.java
* 굿즈 구매 상점의 뷰 페이지를 구현하기 위한 컨트롤러 입니다.
* 임시로 2번의 유저를 넣어두었으나 추후 삭제가 필요합니다.

#### Goods.java
* `@GeneratedValue(strategy = GenerationType.IDENTITY)` 어노테이션이 필요하지 않아 삭제하였습니다.

#### GoodsService.java
* 다른 메서드에서 userId와 goodsId를 반대로 주고있어 수정하였습니다.

#### normalize.css
* CSS가 일관되게 적용되기 위해 추가하였습니다.

#### admin-page.js
* 관리자 뷰 사이드바에서 굿즈를 가져오기 위해 비동기 처리 로직을 추가하였습니다.

#### admin.html
* 관리자 뷰 페이지를 일관되게 보여주기 위해 수정되었습니다.

#### header.html
* 일부 구현된 페이지를 thymeleaf를 사용하여 작동되게 구현하였습니다.

#### sidebar.html
* 관리자 뷰 페이지에서 로그아웃 기능과 굿즈 관리 메뉴를 추가하였습니다.

#### goods-manager.html
#### goods.html
* 관리자의 굿즈 관리 페이지를 구현하였습니다.

#### user.html
* 숫자 포매팅을 사용하여 천 단위의 숫자는 온점으로 구분되게 수정하였습니다.

#### users.html
* 관리자의 유저 관리 메뉴가 너무 강력하다 생각해 유저를 비활성화 하는 기능을 추가하였습니다.


