### PR TITLE
게시글 이미지 추가

### DIFF
--- a/src/main/java/com/walking/project_walking/domain/PostImages.java
+++ b/src/main/java/com/walking/project_walking/domain/PostImages.java
@@ -1,0 +1,29 @@
+package com.walking.project_walking.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "post_images")
+@Getter
+@Setter
+@NoArgsConstructor
+public class PostImages {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "post_id", nullable = false)
+    private Long postId;
+
+    @Column(name = "image_url", length = 512, nullable = false)
+    private String imageUrl;
+
+    public PostImages(Long postId, String imageUrl) {
+        this.postId = postId;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/com/walking/project_walking/domain/dto/PostResponseDto.java
+++ b/src/main/java/com/walking/project_walking/domain/dto/PostResponseDto.java
@@ -3,6 +3,7 @@ package com.walking.project_walking.domain.dto;
 import com.walking.project_walking.domain.Posts;
 import lombok.Getter;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 public class PostResponseDto {
@@ -14,8 +15,9 @@ public class PostResponseDto {
     private Integer viewCount;
     private Integer likes;
     private String nickname;
+    private List<String> imageUrl;
 
-    public static PostResponseDto fromEntity(Posts post, Integer commentsNumber, String nickname) {
+    public static PostResponseDto fromEntity(Posts post, Integer commentsNumber, String nickname, List<String> imageUrl) {
         PostResponseDto dto = new PostResponseDto();
         dto.boardId = post.getBoardId();
         dto.createdAt = post.getCreatedAt();
@@ -25,7 +27,7 @@ public class PostResponseDto {
         dto.viewCount = post.getViewCount();
         dto.likes = post.getLikes();
         dto.nickname = nickname;
+        dto.imageUrl = imageUrl;
         return dto;
     }
-
 }

--- a/src/main/java/com/walking/project_walking/repository/PostImagesRepository.java
+++ b/src/main/java/com/walking/project_walking/repository/PostImagesRepository.java
@@ -1,0 +1,15 @@
+package com.walking.project_walking.repository;
+
+import com.walking.project_walking.domain.PostImages;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PostImagesRepository extends JpaRepository<PostImages, Long> {
+    @Query("SELECT p.imageUrl FROM PostImages p WHERE p.postId = :postId")
+    List<String> findImageUrlsByPostId(@Param("postId") Long postId);
+}

--- a/src/main/java/com/walking/project_walking/service/PostsService.java
+++ b/src/main/java/com/walking/project_walking/service/PostsService.java
@@ -3,6 +3,7 @@ package com.walking.project_walking.service;
 import com.walking.project_walking.domain.Posts;
 import com.walking.project_walking.domain.dto.*;
 import com.walking.project_walking.repository.CommentsRepository;
+import com.walking.project_walking.repository.PostImagesRepository;
 import com.walking.project_walking.repository.PostsRepository;
 import com.walking.project_walking.repository.UserRepository;
 import lombok.*;
@@ -20,6 +21,7 @@ public class PostsService {
     private final PostsRepository postsRepository;
     private final CommentsRepository commentsRepository;
     private final UserRepository userRepository;
+    private final PostImagesRepository postImagesRepository;
 
     private static final double THRESHOLD = 100.0;
 
@@ -30,7 +32,8 @@ public class PostsService {
                 .map(post -> {
                     Integer commentsNumber = commentsRepository.countCommentsByPostId(post.getPostId());
                     String postNickname = userRepository.getNicknameByUserId(post.getUserId());
-                    return PostResponseDto.fromEntity(post, commentsNumber, postNickname);
+                    List<String> imageUrl = postImagesRepository.findImageUrlsByPostId(post.getPostId());
+                    return PostResponseDto.fromEntity(post, commentsNumber, postNickname, imageUrl);
                 }).toList();
     }
 
@@ -49,7 +52,8 @@ public class PostsService {
                 .map(post -> {
                     Integer commentsNumber = commentsRepository.countCommentsByPostId(post.getPostId());
                     String postNickname = userRepository.getNicknameByUserId(post.getUserId());
-                    return PostResponseDto.fromEntity(post, commentsNumber, postNickname);
+                    List<String> imageUrl = postImagesRepository.findImageUrlsByPostId(post.getPostId());
+                    return PostResponseDto.fromEntity(post, commentsNumber, postNickname, imageUrl);
                 })
                 .toList();
     }
@@ -61,7 +65,8 @@ public class PostsService {
                 .map(post -> {
                     Integer commentsNumber = commentsRepository.countCommentsByPostId(post.getPostId());
                     String postNickname = userRepository.getNicknameByUserId(post.getUserId());
-                    return PostResponseDto.fromEntity(post, commentsNumber, postNickname);
+                    List<String> imageUrl = postImagesRepository.findImageUrlsByPostId(post.getPostId());
+                    return PostResponseDto.fromEntity(post, commentsNumber, postNickname, imageUrl);
                 })
                 .toList();
     }
@@ -76,7 +81,8 @@ public class PostsService {
                 .map(post -> {
                     Integer commentsNumber = commentsRepository.countCommentsByPostId(post.getPostId());
                     String postNickname = userRepository.getNicknameByUserId(post.getUserId());
-                    return PostResponseDto.fromEntity(post, commentsNumber, postNickname);
+                    List<String> imageUrl = postImagesRepository.findImageUrlsByPostId(post.getPostId());
+                    return PostResponseDto.fromEntity(post, commentsNumber, postNickname, imageUrl);
                 })
                 .orElse(null);
     }

--- a/src/main/resources/static/js/board-list.js
+++ b/src/main/resources/static/js/board-list.js
@@ -106,10 +106,11 @@ function fetchPopularPosts(boardId) {
         .then(data => {
             if (data) {
                 const popularPosts = document.getElementById('popular-posts');
+                const imageUrl = data.imageUrl[0] || "https://walkingproject.s3.ap-northeast-2.amazonaws.com/41166136-8ormi.jpg";
                 popularPosts.innerHTML = `
                     <h4>${data.title}</h4>
                     <p>${data.content}</p>
-                    <img src="https://placehold.co/30x30" alt="Placeholder Image">
+                    <img src= "${imageUrl}" alt="Placeholder Image">
                     <p>작성일: ${data.createdAt}</p>
                     <p>조회수: ${data.viewCount}</p>
                     <p>좋아요: ${data.likes}</p>
@@ -207,10 +208,11 @@ function displayPosts(posts) {
 
     posts.forEach(post => {
         const li = document.createElement('li');
+        const imageUrl = post.imageUrl[0] || "https://walkingproject.s3.ap-northeast-2.amazonaws.com/41166136-8ormi.jpg";
         li.innerHTML = `
             <h4>${post.title}</h4>
             <p>${post.content}</p>
-            <img src="https://placehold.co/30x30" alt="Placeholder Image">
+            <img src= "${imageUrl}" alt="Placeholder Image">
             <p>작성일: ${post.createdAt}</p>
             <p>조회수: ${post.viewCount}</p>
             <p>좋아요: ${post.likes}</p>


### PR DESCRIPTION
### PostImages
- 특정 게시글에 어떤 이미들을 포함하고 있는지 확인하는 도메인

### PostResponseDto
- 게시물을 반환할 때 해당 게시물에 포함된 이미지 URL도 함께 반환되로록 수정

### PostImageRepository
- post_images 테이블에서 post_id를 통해 이미지 URL을 찾아올 수 있는 기능 생성

### PostsService
- 게시글 관련 메소드에서 이미지 URL 관련 수정

### board-list.js
- 게시글의 첫번째 이미지가 섬네일로 출력되도록 변경
- 게시글에 이미지가 없을 경우 DEFAULT 이미지가 출력되도록 변경